### PR TITLE
Bump gRPC-haskell version

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -10,8 +10,8 @@ let
   grpc-haskell-src = pkgs.fetchFromGitHub {
     owner  = "awakesecurity";
     repo   = "gRPC-haskell";
-    rev    = "28e9e68f3b6ba85358982a93dcc1433139524585";
-    sha256 = "0k9k7gmyjvng1sml2zhvc91g5ilrd3qwzpzv3zrx4v2bxj7s554p";
+    rev    = "e1091b9c0dc9dee8354cf63c9aebe51fa041cfd9";
+    sha256 = "0rkmcd0rnhbh4da65477hdsh3j70ma38wi1qq953bb509byhilp8";
   };
 
   proto-files = ./proto;

--- a/src/Network/GRPC/MQTT/Wrapping.hs
+++ b/src/Network/GRPC/MQTT/Wrapping.hs
@@ -82,7 +82,6 @@ import Proto.Mqtt as Proto (
 import Control.Exception (ErrorCall, try)
 import Data.ByteString.Base64 (decodeBase64, encodeBase64)
 import qualified Data.Map as M
-import Data.SortedList (fromSortedList, toSortedList)
 import qualified Data.Vector as V
 import GHC.IO.Unsafe (unsafePerformIO)
 import Network.GRPC.HighLevel as HL (
@@ -278,7 +277,7 @@ parseWithClientError = first (GRPCResult . ClientErrorResponse . ClientErrorNoPa
 toMetadataMap :: Proto.MetadataMap -> HL.MetadataMap
 toMetadataMap (Proto.MetadataMap m) = HL.MetadataMap (convertVals <$> M.mapKeys convertKeys m)
  where
-  convertVals = maybe [] (toSortedList . V.toList . listValue)
+  convertVals = maybe [] (V.toList . listValue)
   convertKeys k =
     case decodeBase64 $ encodeUtf8 k of
       Left _err -> mempty
@@ -287,7 +286,7 @@ toMetadataMap (Proto.MetadataMap m) = HL.MetadataMap (convertVals <$> M.mapKeys 
 fromMetadataMap :: HL.MetadataMap -> Proto.MetadataMap
 fromMetadataMap (HL.MetadataMap m) = Proto.MetadataMap (convertVals <$> M.mapKeys convertKeys m)
  where
-  convertVals = Just . List . V.fromList . fromSortedList
+  convertVals = Just . List . V.fromList
   convertKeys = fromStrict . encodeBase64
 
 toStatusCode :: Int32 -> Maybe StatusCode


### PR DESCRIPTION
Updated to use the latest `grpc-haskell` version.

The `MetadataMap` datatype was changed to no long use a `SortedList`, so those wrappers were removed. This internal format change should not affect the handling of the `MetadataMap` type in this library since we are just transporting the metadata to the remote client.