### PR TITLE
Add logging 

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -75,6 +75,7 @@ library
   exposed-modules:    Network.GRPC.MQTT
                       Network.GRPC.MQTT.Client
                       Network.GRPC.MQTT.Core
+                      Network.GRPC.MQTT.Logging
                       Network.GRPC.MQTT.RemoteClient
                       Network.GRPC.MQTT.Sequenced
                       Network.GRPC.MQTT.TH.Client

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -21,11 +21,11 @@ import Proto.Mqtt (
   RemoteClientError,
  )
 
-import Network.GRPC.MQTT.Core (MQTTConnectionConfig, connectMQTT, heartbeatPeriodSeconds, setCallback)
+import Network.GRPC.MQTT.Core (MQTTConnectionConfig, connectMQTT, heartbeatPeriodSeconds, setCallback, Logger, logErr, logDebug)
 import Network.GRPC.MQTT.Sequenced (mkSequencedRead)
 import Network.GRPC.MQTT.Types (
   MQTTRequest (MQTTNormalRequest, MQTTReaderRequest),
-  MQTTResult (GRPCResult),
+  MQTTResult (GRPCResult, MQTTError),
  )
 import Network.GRPC.MQTT.Wrapping (
   fromRemoteClientError,
@@ -84,15 +84,17 @@ data MQTTGRPCClient = MQTTGRPCClient
     responseChan :: TChan LByteString
   , -- | Random number generator for generating session IDs
     rng :: Generator
+  , -- | Logging 
+    mqttLogger :: Logger
   }
 
 {- | Connects to the MQTT broker using the supplied 'MQTTConfig' and passes the `MQTTGRPCClient' to the supplied function, closing the connection for you when the function finishes.
  Disconnects from the MQTT broker with 'normalDisconnect' when finished.
 -}
-withMQTTGRPCClient :: MQTTConnectionConfig -> (MQTTGRPCClient -> IO a) -> IO a
-withMQTTGRPCClient cfg =
+withMQTTGRPCClient :: Logger -> MQTTConnectionConfig -> (MQTTGRPCClient -> IO a) -> IO a
+withMQTTGRPCClient logger cfg =
   bracket
-    (connectMQTTGRPC cfg)
+    (connectMQTTGRPC logger cfg)
     (normalDisconnect . mqttClient)
 
 {- | Send a gRPC request over MQTT using the provided client
@@ -107,6 +109,8 @@ mqttRequest ::
   MQTTRequest streamtype request response ->
   IO (MQTTResult streamtype response)
 mqttRequest MQTTGRPCClient{..} baseTopic (MethodName method) request = do
+  logDebug mqttLogger $ "Making gRPC request for method: " <> decodeUtf8 method
+  
   sessionID <- nonce128urlT rng
   let responseTopic = baseTopic <> "/grpc/session/" <> sessionID
   let requestTopic = baseTopic <> "/grpc/request" <> decodeUtf8 method
@@ -114,6 +118,7 @@ mqttRequest MQTTGRPCClient{..} baseTopic (MethodName method) request = do
 
   let publishRequest :: request -> TimeoutSeconds -> HL.MetadataMap -> IO ()
       publishRequest req timeLimit reqMetadata = do
+        logDebug mqttLogger $ "Publishing message to topic: " <> responseTopic
         let wrappedReq = wrapRequest responseTopic timeLimit reqMetadata req
         publishq mqttClient requestTopic wrappedReq False QoS1 []
 
@@ -123,70 +128,80 @@ mqttRequest MQTTGRPCClient{..} baseTopic (MethodName method) request = do
         ctrlMessage = toLazyByteString $ AuxControlMessage (Enumerated (Right ctrl))
 
   let sendTerminateOnException :: IO a -> IO a
-      sendTerminateOnException action = action `onException` publishControlMsg AuxControlTerminate
+      sendTerminateOnException action = onException action $ do
+        logErr mqttLogger "Exception while waiting for response"
+        publishControlMsg AuxControlTerminate
 
   -- Subscribe to response topic
-  _ <- subscribe mqttClient [(responseTopic, subOptions{_subQoS = QoS1})] []
+  (subResults, _) <- subscribe mqttClient [(responseTopic, subOptions{_subQoS = QoS1})] []
+  case subResults of
+    [Left subErr] -> do
+      let errMsg = "Failed to subscribe to the topic: " <> responseTopic <> "Reason: " <> show subErr
+      logErr mqttLogger errMsg
+      return $ MQTTError errMsg
+        
+    _ -> do
+      -- Process request
+      case request of
+        -- Unary Requests
+        MQTTNormalRequest req timeLimit reqMetadata ->
+          grpcTimeout timeLimit $ do
+            publishRequest req timeLimit reqMetadata
+            sendTerminateOnException $
+              unwrapUnaryResponse <$> atomically (readTChan responseChan)
 
-  -- Process request
-  case request of
-    -- Unary Requests
-    MQTTNormalRequest req timeLimit reqMetadata ->
-      grpcTimeout timeLimit $ do
-        publishRequest req timeLimit reqMetadata
-        sendTerminateOnException $
-          unwrapUnaryResponse <$> atomically (readTChan responseChan)
+        -- Server Streaming Requests
+        MQTTReaderRequest req timeLimit reqMetadata streamHandler ->
+          grpcTimeout timeLimit $ do
+            publishRequest req timeLimit reqMetadata
 
-    -- Server Streaming Requests
-    MQTTReaderRequest req timeLimit reqMetadata streamHandler ->
-      grpcTimeout timeLimit $ do
-        publishRequest req timeLimit reqMetadata
+            let withMQTTHeartbeat :: IO a -> IO a
+                withMQTTHeartbeat action =
+                  withAsync
+                    (forever (publishControlMsg AuxControlAlive >> sleep heartbeatPeriodSeconds))
+                    (const action)
 
-        let withMQTTHeartbeat :: IO a -> IO a
-            withMQTTHeartbeat action =
-              withAsync
-                (forever (publishControlMsg AuxControlAlive >> sleep heartbeatPeriodSeconds))
-                (const action)
+            withMQTTHeartbeat . sendTerminateOnException $ do
+              let readUnwrapped = unwrapSequencedResponse . toStrict <$> readTChan responseChan
+              orderedRead <- mkSequencedRead readUnwrapped
 
-        withMQTTHeartbeat . sendTerminateOnException $ do
-          let readUnwrapped = unwrapSequencedResponse . toStrict <$> readTChan responseChan
-          orderedRead <- mkSequencedRead readUnwrapped
+              let readInitMetadata :: IO (Either RemoteClientError HL.MetadataMap)
+                  readInitMetadata = do
+                    rawInitMD <- orderedRead
+                    let parsedMD = first parseErrorToRCE . fromByteString =<< rawInitMD
+                    return $ fmap toMetadataMap parsedMD
 
-          let readInitMetadata :: IO (Either RemoteClientError HL.MetadataMap)
-              readInitMetadata = do
-                rawInitMD <- orderedRead
-                let parsedMD = first parseErrorToRCE . fromByteString =<< rawInitMD
-                return $ fmap toMetadataMap parsedMD
+              -- Wait for initial metadata
+              readInitMetadata >>= \case
+                Left err -> pure $ fromRemoteClientError err
+                Right metadata -> do
+                  -- Adapter to recieve stream from MQTT
+                  let mqttSRecv = unwrapStreamChunk <$> orderedRead
 
-          -- Wait for initial metadata
-          readInitMetadata >>= \case
-            Left err -> pure $ fromRemoteClientError err
-            Right metadata -> do
-              -- Adapter to recieve stream from MQTT
-              let mqttSRecv = unwrapStreamChunk <$> orderedRead
+                  -- Run user-provided stream handler
+                  streamHandler metadata mqttSRecv
 
-              -- Run user-provided stream handler
-              streamHandler metadata mqttSRecv
-
-              -- Return final result
-              unwrapStreamResponse <$> atomically (readTChan responseChan)
+                  -- Return final result
+                  unwrapStreamResponse <$> atomically (readTChan responseChan)
 
 {- | Connects to the MQTT broker and creates a 'MQTTGRPCClient'
  NB: Overwrites the '_msgCB' field in the 'MQTTConfig'
 -}
-connectMQTTGRPC :: (MonadIO m) => MQTTConnectionConfig -> m MQTTGRPCClient
-connectMQTTGRPC cfg = do
+connectMQTTGRPC :: (MonadIO m) => Logger -> MQTTConnectionConfig -> m MQTTGRPCClient
+connectMQTTGRPC logger cfg = do
   resultChan <- newTChanIO
 
   let clientMQTTHandler :: MessageCallback
       clientMQTTHandler =
-        SimpleCallback $ \_client _topic mqttMessage _props -> do
+        SimpleCallback $ \_client topic mqttMessage _props -> do
+          logDebug logger $ "clientMQTTHandler received message on topic: " <> topic
           atomically $ writeTChan resultChan mqttMessage
 
   MQTTGRPCClient
     <$> connectMQTT (cfg & setCallback clientMQTTHandler)
     <*> pure resultChan
     <*> new
+    <*> pure logger
 
 -- | Returns a 'GRPCIOTimeout' error if the supplied function takes longer than the given timeout.
 grpcTimeout :: (MonadUnliftIO m) => TimeoutSeconds -> m (MQTTResult streamType response) -> m (MQTTResult streamType response)

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -11,18 +11,18 @@ module Network.GRPC.MQTT.Core (
   heartbeatPeriodSeconds,
   setCallback,
   setConnectionId,
-  Logger (..),
-  Verbosity (..),
-  logErr,
-  logWarn,
-  logInfo,
-  logDebug,
-  noLogging
 ) where
 
 import Relude
 
-import Data.Conduit.Network (AppData, ClientSettings, appSink, appSource, clientSettings, runTCPClient)
+import Data.Conduit.Network (
+  AppData,
+  ClientSettings,
+  appSink,
+  appSource,
+  clientSettings,
+  runTCPClient,
+ )
 import Data.Conduit.Network.TLS (
   TLSClientConfig (tlsClientTLSSettings),
   runTLSClient,
@@ -31,39 +31,11 @@ import Data.Conduit.Network.TLS (
 import Network.MQTT.Client (
   MQTTClient,
   MQTTConduit,
-  MQTTConfig (MQTTConfig, _connID, _hostname, _msgCB, _port, _tlsSettings),
+  MQTTConfig (..),
   MessageCallback,
   runMQTTConduit,
  )
 import Turtle (NominalDiffTime)
-
-data Logger = Logger
-  { log :: Text -> IO ()
-  , verbosity :: Verbosity
-  }
-
-noLogging :: Logger
-noLogging = Logger (\_ -> pure ()) Silent
-
-data Verbosity
-  = Silent
-  | Error
-  | Warn
-  | Info
-  | Debug
-  deriving (Show, Eq, Enum, Ord)
-
-logErr :: Logger -> Text -> IO ()
-logErr = logVerbosity Error
-logWarn :: Logger -> Text -> IO ()
-logWarn = logVerbosity Warn
-logInfo :: Logger -> Text -> IO ()
-logInfo = logVerbosity Info
-logDebug :: Logger -> Text -> IO ()
-logDebug = logVerbosity Debug
-
-logVerbosity :: Verbosity -> Logger -> Text -> IO ()
-logVerbosity v logger msg = when (verbosity logger >= v) $ log logger msg
 
 {- |
   Wrapper around 'MQTTConfig' indicating whether or not to use TLS for the
@@ -73,10 +45,12 @@ data MQTTConnectionConfig
   = Secured MQTTConfig
   | Unsecured MQTTConfig
 
+-- | Utility for setting the callback within the 'MQTTConfig'
 setCallback :: MessageCallback -> MQTTConnectionConfig -> MQTTConnectionConfig
 setCallback cb (Secured cfg) = Secured cfg{_msgCB = cb}
 setCallback cb (Unsecured cfg) = Unsecured cfg{_msgCB = cb}
 
+-- | Utility for setting the connection ID within the 'MQTTConfig'
 setConnectionId :: String -> MQTTConnectionConfig -> MQTTConnectionConfig
 setConnectionId cid (Secured cfg) = Secured cfg{_connID = cid}
 setConnectionId cid (Unsecured cfg) = Unsecured cfg{_connID = cid}

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -1,0 +1,36 @@
+{-
+  Copyright (c) 2021 Arista Networks, Inc.
+  Use of this source code is governed by the Apache License 2.0
+  that can be found in the COPYING file.
+-}
+module Network.GRPC.MQTT.Logging where
+
+import Relude
+
+data Logger = Logger
+  { log :: Text -> IO ()
+  , verbosity :: Verbosity
+  }
+
+data Verbosity
+  = Silent
+  | Error
+  | Warn
+  | Info
+  | Debug
+  deriving (Show, Eq, Enum, Ord)
+
+noLogging :: Logger
+noLogging = Logger (\_ -> pure ()) Silent
+
+logErr :: Logger -> Text -> IO ()
+logErr = logVerbosity Error
+logWarn :: Logger -> Text -> IO ()
+logWarn = logVerbosity Warn
+logInfo :: Logger -> Text -> IO ()
+logInfo = logVerbosity Info
+logDebug :: Logger -> Text -> IO ()
+logDebug = logVerbosity Debug
+
+logVerbosity :: Verbosity -> Logger -> Text -> IO ()
+logVerbosity v logger msg = when (verbosity logger >= v) $ log logger msg

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -1,9 +1,8 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE RecordWildCards #-}
 
 module Network.GRPC.MQTT.RemoteClient (runRemoteClient) where
@@ -11,9 +10,14 @@ module Network.GRPC.MQTT.RemoteClient (runRemoteClient) where
 import Relude
 
 import Network.GRPC.MQTT.Core (
+  Logger,
   MQTTConnectionConfig,
   connectMQTT,
   heartbeatPeriodSeconds,
+  logDebug,
+  logErr,
+  logInfo,
+  logWarn,
   setCallback,
  )
 import Network.GRPC.MQTT.Sequenced (mkSequencedPublish)
@@ -43,6 +47,7 @@ import Network.GRPC.HighLevel.Client (
  )
 import Network.MQTT.Client (
   MQTTClient,
+  MQTTException,
   MessageCallback (SimpleCallback),
   QoS (QoS1),
   SubOptions (_subQoS),
@@ -64,11 +69,10 @@ import Proto3.Suite (
   Message,
   fromByteString,
  )
-import System.IO (hPutStrLn)
 import Turtle (NominalDiffTime)
 import UnliftIO (timeout)
-import UnliftIO.Async (Async, async, cancel, waitEither_, withAsync)
-import UnliftIO.Exception (throwString, tryAny)
+import UnliftIO.Async (Async, async, cancel, waitEither, withAsync)
+import UnliftIO.Exception (throwString, try, tryAny)
 
 -- | Represents the session ID for a request
 type SessionId = Text
@@ -86,6 +90,7 @@ data Session = Session
 
 -- | The serverside adapter acts as a remote gRPC client.
 runRemoteClient ::
+  Logger ->
   -- | MQTT configuration for connecting to the MQTT broker
   MQTTConnectionConfig ->
   -- | Base topic which should uniquely identify the device
@@ -93,33 +98,48 @@ runRemoteClient ::
   -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   MethodMap ->
   IO ()
-runRemoteClient cfg baseTopic methodMap = do
+runRemoteClient logger cfg baseTopic methodMap = do
   currentSessions <- newTVarIO mempty
   let gatewayConfig = cfg & setCallback (gatewayHandler currentSessions)
   bracket (connectMQTT gatewayConfig) normalDisconnect $ \gatewayMQTTClient -> do
+    logInfo logger "Connected to MQTT Broker"
+
     -- Subscribe to listen for all gRPC requests
     let listeningTopic = baseTopic <> "/grpc/request/+/+"
-    _ <- subscribe gatewayMQTTClient [(listeningTopic, subOptions{_subQoS = QoS1})] []
-
-    waitForClient gatewayMQTTClient
+    (subResults, _) <- subscribe gatewayMQTTClient [(listeningTopic, subOptions{_subQoS = QoS1})] []
+    case subResults of
+      [Left subErr] ->
+        logErr logger $
+          "Remote Client failed to subscribe to the topic: " <> listeningTopic <> "Reason: " <> show subErr
+      _ -> do
+        try (waitForClient gatewayMQTTClient) >>= \case
+          Left (e :: MQTTException) ->
+            logErr logger $
+              "MQTT client connection terminated with exception: " <> toText (displayException e)
+          Right () ->
+            logInfo
+              logger
+              "MQTT client connection terminated normally"
  where
   gatewayHandler :: SessionMap -> MessageCallback
   gatewayHandler currentSessions = SimpleCallback $ \client topic mqttMessage _props -> do
+    logInfo logger $ "Remote Client received request at topic: " <> topic
+
     result <- tryAny $ case T.splitOn "/" topic of
       [_, _, "grpc", "request", service, method] ->
         let grpcMethod = encodeUtf8 ("/" <> service <> "/" <> method)
-         in makeGRPCRequest methodMap currentSessions client grpcMethod mqttMessage
-      [_, _, "grpc", "session", sessionId, "control"] -> manageSession currentSessions sessionId mqttMessage
-      _ -> throwString $ "Failed to parse topic: " <> toString topic
+         in makeGRPCRequest logger methodMap currentSessions client grpcMethod mqttMessage
+      [_, _, "grpc", "session", sessionId, "control"] -> manageSession logger currentSessions sessionId mqttMessage
+      _ -> logErr logger $ "Failed to parse topic: " <> topic
 
     -- Catch and print any synchronous exception. We don't want an exception
     -- from an individual callback thread to take down the entire MQTT client.
-    case result of
-      Left err -> hPutStrLn stderr $ displayException err
-      Right () -> pure ()
+    whenLeft_ result $ \err ->
+      logErr logger $ "gatewayHandler terminated with exception: " <> toText (displayException err)
 
 -- | Perform the local gRPC call and publish the response
 makeGRPCRequest ::
+  Logger ->
   -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   MethodMap ->
   -- | The map of the current sessions
@@ -131,30 +151,50 @@ makeGRPCRequest ::
   -- | The raw MQTT message
   LByteString ->
   IO ()
-makeGRPCRequest methodMap currentSessions client grpcMethod mqttMessage = do
+makeGRPCRequest logger methodMap currentSessions client grpcMethod mqttMessage = do
+  logInfo logger $ "Received request for the gRPC method: " <> decodeUtf8 grpcMethod
+
   (WrappedMQTTRequest lResponseTopic timeLimit reqMetadata payload) <-
     case fromByteString (toStrict mqttMessage) of
-      -- Really can't do anything if we can't parse out the response topic
-      Left err -> throwString $ "Decode wrapped request failed" <> show err
+      Left err -> throwString $ "Failed to decode MQTT message: " <> show err
       Right x -> pure x
 
   let responseTopic = toStrict lResponseTopic
-  let publishResponse msg = publishq client responseTopic msg False QoS1 []
+  let publishResponse msg = do
+        logDebug logger $
+          "Publishing response to topic: " <> responseTopic <> " Raw message: " <> decodeUtf8 msg
+        publishq client responseTopic msg False QoS1 []
+
+  logDebug logger $
+    "Wrapped request data: "
+      <> "Response Topic: "
+      <> responseTopic
+      <> "Timeout: "
+      <> show timeLimit
+      <> "Metadata: "
+      <> show reqMetadata
 
   publishResponseSequenced <- mkSequencedPublish publishResponse
 
   case lookup grpcMethod methodMap of
-    Nothing ->
-      publishResponse . wrapMQTTError $ "Failed to find client for: " <> decodeUtf8 grpcMethod
+    Nothing -> do
+      let errMsg = "Failed to find gRPC client for: " <> decodeUtf8 grpcMethod
+      logErr logger (toStrict errMsg)
+      publishResponse $ wrapMQTTError errMsg
     -- Run Unary Request
     Just (ClientUnaryHandler handler) -> do
+      logDebug logger $ "Found unary client handler for: " <> decodeUtf8 grpcMethod
       response <- handler payload (fromIntegral timeLimit) (maybe mempty toMetadataMap reqMetadata)
       publishResponse $ wrapUnaryResponse response
     -- Run Server Streaming Request
     Just (ClientServerStreamHandler handler) -> do
+      logDebug logger $ "Found streaming client handler for: " <> decodeUtf8 grpcMethod
       getSessionId currentSessions responseTopic >>= \case
-        Left err -> publishResponse . wrapMQTTError $ toLazy err
-        Right sessionId -> bracket (sessionInit sessionId) (sessionCleanup sessionId) waitWithHeartbeatMonitor
+        Left err -> do
+          logErr logger err
+          publishResponse . wrapMQTTError $ toLazy err
+        Right sessionId -> do
+          bracket (sessionInit sessionId) (sessionCleanup sessionId) waitWithHeartbeatMonitor
      where
       controlTopic :: Topic
       controlTopic = responseTopic <> "/control"
@@ -166,19 +206,26 @@ makeGRPCRequest methodMap currentSessions client grpcMethod mqttMessage = do
 
       sessionInit :: Text -> IO Session
       sessionInit sessionId = do
-        _ <- subscribe client [(controlTopic, subOptions{_subQoS = QoS1})] []
+        (subResults, _) <- subscribe client [(controlTopic, subOptions{_subQoS = QoS1})] []
+        case subResults of
+          [Left subErr] ->
+            throwString $
+              "Failed to subscribe to the topic: " <> toString controlTopic <> "Reason: " <> show subErr
+          _ -> do
+            logInfo logger $ "Begin new streaming session: " <> sessionId
 
-        newSession <-
-          Session
-            <$> async runHandler
-            <*> newTMVarIO ()
+            newSession <-
+              Session
+                <$> async runHandler
+                <*> newTMVarIO ()
 
-        atomically $ modifyTVar' currentSessions (Map.insert sessionId newSession)
+            atomically $ modifyTVar' currentSessions (Map.insert sessionId newSession)
 
-        return newSession
+            return newSession
 
       sessionCleanup :: Text -> Session -> IO ()
       sessionCleanup sessionId session = do
+        logInfo logger $ "Cleanup streaming session: " <> sessionId
         atomically $ modifyTVar' currentSessions (Map.delete sessionId)
         cancel $ handlerThread session
         _ <- unsubscribe client [controlTopic] []
@@ -187,27 +234,35 @@ makeGRPCRequest methodMap currentSessions client grpcMethod mqttMessage = do
       waitWithHeartbeatMonitor :: Session -> IO ()
       waitWithHeartbeatMonitor Session{..} =
         withAsync heartbeatMon $ \heartbeatThread ->
-          waitEither_ handlerThread heartbeatThread
+          waitEither handlerThread heartbeatThread >>= \case
+            Left () -> logDebug logger "handlerThread completed"
+            Right () -> logWarn logger "Timed out waiting for heartbeat"
        where
         -- Wait slightly longer than the heartbeatPeriod to allow for network delays
         heartbeatMon = watchdog (heartbeatPeriodSeconds + 1) sessionHeartbeat
 
 -- | Handles AuxControl signals from the "/control" topic
-manageSession :: SessionMap -> SessionId -> LByteString -> IO ()
-manageSession currentSessions sessionId mqttMessage =
+manageSession :: Logger -> SessionMap -> SessionId -> LByteString -> IO ()
+manageSession logger currentSessions sessionId mqttMessage =
   case fromByteString (toStrict mqttMessage) of
     Right (AuxControlMessage (Enumerated (Right AuxControlTerminate))) -> do
+      logInfo logger $ "Received terminate message for session: " <> sessionId
+
       mSession <- atomically $ do
         mSession <- Map.lookup sessionId <$> readTVar currentSessions
         modifyTVar' currentSessions (Map.delete sessionId)
         return mSession
       whenJust mSession (cancel . handlerThread)
-    Right (AuxControlMessage (Enumerated (Right AuxControlAlive))) ->
+    Right (AuxControlMessage (Enumerated (Right AuxControlAlive))) -> do
+      logDebug logger $ "Received heartbeat message for session: " <> sessionId
+
       whenJustM
         (Map.lookup sessionId <$> readTVarIO currentSessions)
         (\Session{..} -> void . atomically $ tryPutTMVar sessionHeartbeat ())
-    -- Unknown Control Message
-    ctrl -> throwString $ "Unknown ctrl message: " <> show ctrl
+    Right ctrl ->
+      logWarn logger $ "Received unknown control message: " <> show ctrl <> " for session: " <> sessionId
+    Left err ->
+      logErr logger $ "Failed to parse control message for session " <> sessionId <> ": " <> show err
 
 {- | Parses the session ID out of the response topic and checks that
  the session ID is not already in use
@@ -221,7 +276,7 @@ getSessionId sessions topic = runExceptT $ do
 
   sessionExists <- Map.member sessionId <$> readTVarIO sessions
   when sessionExists $
-    throwError "Session already exists"
+    throwError $ "Session already exists: " <> sessionId
 
   return sessionId
 

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -20,6 +20,7 @@ import Test.Helpers (
   getTestConfig,
   notParallel,
   streamTester,
+  testLogger,
   timeit,
  )
 import Test.ProtoClients (
@@ -41,8 +42,16 @@ import Network.GRPC.MQTT (
   subOptions,
   subscribe,
  )
-import Network.GRPC.MQTT.Client (MQTTGRPCClient (mqttClient), withMQTTGRPCClient)
-import Network.GRPC.MQTT.Core (MQTTConnectionConfig, connectMQTT, noLogging, setCallback, setConnectionId)
+import Network.GRPC.MQTT.Client (
+  MQTTGRPCClient (mqttClient),
+  withMQTTGRPCClient,
+ )
+import Network.GRPC.MQTT.Core (
+  MQTTConnectionConfig,
+  connectMQTT,
+  setCallback,
+  setConnectionId,
+ )
 import Network.GRPC.MQTT.RemoteClient (runRemoteClient)
 import Network.GRPC.MQTT.Sequenced (
   SequenceIdx (SequencedIdx),
@@ -62,11 +71,7 @@ import Data.Time.Clock (
 import Network.GRPC.HighLevel.Client (
   ClientConfig (..),
   ClientError (ClientIOError),
-  ClientResult (
-    ClientErrorResponse,
-    ClientNormalResponse,
-    ClientReaderResponse
-  ),
+  ClientResult (..),
   Port,
   StatusCode (StatusOk),
  )
@@ -158,9 +163,9 @@ persistentMQTT = do
     withGRPCClient (testGrpcClientConfig addHelloServerPort) $ \grpcClient -> do
       methodMap <- addHelloRemoteClientMethodMap grpcClient
       -- Start serverside MQTT adaptor
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptor") testBaseTopic methodMap) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptor") testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
-        withMQTTGRPCClient noLogging (awsConfig & setConnectionId testClientId) $ \client -> do
+        withMQTTGRPCClient testLogger (awsConfig & setConnectionId testClientId) $ \client -> do
           let AddHello mqttAdd mqttHelloSS = addHelloMqttClient client testBaseTopic
 
           mqttAdd (MQTTNormalRequest (TwoInts 4 6) 2 []) >>= \case
@@ -195,9 +200,9 @@ streamingTermination = do
       methodMap <- addHelloRemoteClientMethodMap grpcClient
 
       -- Start serverside MQTT adaptor
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptor") testBaseTopic methodMap) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptor") testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
-        withMQTTGRPCClient noLogging (awsConfig & setConnectionId testClientId) $ \client -> do
+        withMQTTGRPCClient testLogger (awsConfig & setConnectionId testClientId) $ \client -> do
           let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
           let testInput = SSRqt "Alice" 1
               request = MQTTReaderRequest testInput 20 [] (streamTester (assertContains "Alice" . ssrpyGreeting))
@@ -210,7 +215,7 @@ testTimeout :: Assertion
 testTimeout = do
   awsConfig <- getTestConfig
 
-  withMQTTGRPCClient noLogging (awsConfig & setConnectionId testClientId) $ \client -> do
+  withMQTTGRPCClient testLogger (awsConfig & setConnectionId testClientId) $ \client -> do
     let AddHello mqttAdd mqttHelloSS = addHelloMqttClient client testBaseTopic
 
     addResponse <- timeit 3 $ mqttAdd (MQTTNormalRequest (TwoInts 9 16) 2 [])
@@ -234,10 +239,10 @@ basicUnary = do
     withGRPCClient (testGrpcClientConfig addHelloServerPort) $ \grpcClient -> do
       methodMap <- addHelloRemoteClientMethodMap grpcClient
       -- Start serverside MQTT adaptor
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptorBU") testBaseTopic methodMap) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptorBU") testBaseTopic methodMap) $ \_adaptorThread -> do
         --Delay to allow remote client to start receiving MQTT messages
         sleep 1
-        withMQTTGRPCClient noLogging (awsConfig & setConnectionId (testClientId <> "BU")) $ \client -> do
+        withMQTTGRPCClient testLogger (awsConfig & setConnectionId (testClientId <> "BU")) $ \client -> do
           let AddHello mqttAdd _ = addHelloMqttClient client testBaseTopic
           let testInput = TwoInts 4 6
               expectedResult = OneInt 10
@@ -259,7 +264,7 @@ basicServerStreaming = do
       methodMap <- addHelloRemoteClientMethodMap grpcClient
 
       -- Start serverside MQTT adaptor
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptorSS") testBaseTopic methodMap) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptorSS") testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
         testHelloCall (awsConfig & setConnectionId (testClientId <> "SS"))
 
@@ -272,9 +277,9 @@ missingClientError = do
     -- Get gRPC Client
     withGRPCClient (testGrpcClientConfig addHelloServerPort) $ \_grpcClient -> do
       -- Start serverside MQTT adaptor
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptorSS") testBaseTopic []) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptorSS") testBaseTopic []) $ \_adaptorThread -> do
         sleep 1
-        withMQTTGRPCClient noLogging (awsConfig & setConnectionId (testClientId <> "SS")) $ \client -> do
+        withMQTTGRPCClient testLogger (awsConfig & setConnectionId (testClientId <> "SS")) $ \client -> do
           let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
               testInput = SSRqt "Alice" 2
               request = MQTTReaderRequest testInput 5 [("alittlebit", "ofinitialmetadata")] (streamTester (assertContains "Alice" . ssrpyGreeting))
@@ -299,7 +304,7 @@ twoServers = do
           methodMapMG <- multGoodbyeRemoteClientMethodMap grpcClient2
           let methodMap = methodMapAH <> methodMapMG
           -- Start serverside MQTT adaptor
-          withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "testMachineSSAdaptorTS") testBaseTopic methodMap) $ \_adaptorThread -> do
+          withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "testMachineSSAdaptorTS") testBaseTopic methodMap) $ \_adaptorThread -> do
             sleep 1
             -- Server 1
             testAddCall (awsConfig & setConnectionId "testclientTS1")
@@ -310,7 +315,7 @@ twoServers = do
             testGoodbyeCall (awsConfig & setConnectionId "testclientTS4")
 
 testAddCall :: MQTTConnectionConfig -> Assertion
-testAddCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
+testAddCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
   let AddHello mqttAdd _ = addHelloMqttClient client testBaseTopic
   let testInput = TwoInts 4 6
       expectedResult = OneInt 10
@@ -322,7 +327,7 @@ testAddCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
     MQTTError err -> assertFailure $ "add mqtt error: " <> show err
 
 testHelloCall :: MQTTConnectionConfig -> Assertion
-testHelloCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
+testHelloCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
   let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
       testInput = SSRqt "Alice" 2
       request = MQTTReaderRequest testInput 5 [("alittlebit", "ofinitialmetadata")] (streamTester (assertContains "Alice" . ssrpyGreeting))
@@ -333,7 +338,7 @@ testHelloCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
     MQTTError err -> assertFailure $ "helloSS mqtt error: " <> show err
 
 testMultCall :: MQTTConnectionConfig -> Assertion
-testMultCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
+testMultCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
   let MultGoodbye mqttMult _ = multGoodbyeMqttClient client testBaseTopic
       testInput = TwoInts 4 6
       expectedResult = OneInt 24
@@ -345,7 +350,7 @@ testMultCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
     MQTTError err -> assertFailure $ "mult mqtt error: " <> show err
 
 testGoodbyeCall :: MQTTConnectionConfig -> Assertion
-testGoodbyeCall cfg = withMQTTGRPCClient noLogging cfg $ \client -> do
+testGoodbyeCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
   let MultGoodbye _ mqttGoodbyeSS = multGoodbyeMqttClient client testBaseTopic
       testInput = SSRqt "Alice" 3
       request = MQTTReaderRequest testInput 10 [] (streamTester (assertContains "Alice" . ssrpyGreeting))
@@ -390,9 +395,9 @@ malformedMessage = do
     withGRPCClient (testGrpcClientConfig addHelloServerPort) $ \grpcClient -> do
       methodMap <- addHelloRemoteClientMethodMap grpcClient
       -- Start serverside MQTT adapter
-      withAsync (runRemoteClient noLogging (awsConfig & setConnectionId "errorTesterRC") testBaseTopic methodMap) $ \_adaptorThread -> do
+      withAsync (runRemoteClient testLogger (awsConfig & setConnectionId "errorTesterRC") testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
-        withMQTTGRPCClient noLogging (awsConfig & setConnectionId (testClientId <> "errorTester")) $ \client -> do
+        withMQTTGRPCClient testLogger (awsConfig & setConnectionId (testClientId <> "errorTester")) $ \client -> do
           -- Publish message for non-existent service
           publishq (mqttClient client) (testBaseTopic <> "/grpc/request/bad/service") "blah" False QoS1 []
           sleep 1

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -1,4 +1,4 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
@@ -23,6 +23,7 @@ import Data.X509.CertificateStore (
  )
 import Network.Connection (TLSSettings (TLSSettings))
 import Network.GRPC.HighLevel.Client (MetadataMap, StreamRecv)
+import Network.GRPC.MQTT.Logging (Logger, noLogging)
 import Network.TLS (
   ClientHooks (onCertificateRequest),
   ClientParams (clientHooks, clientShared, clientSupported),
@@ -35,7 +36,12 @@ import Network.TLS (
   defaultParamsClient,
  )
 import Network.TLS.Extra.Cipher (ciphersuite_default)
-import Test.Tasty (DependencyType (AllFinish), TestName, TestTree, after)
+import Test.Tasty (
+  DependencyType (AllFinish),
+  TestName,
+  TestTree,
+  after,
+ )
 import Test.Tasty.HUnit (
   Assertion,
   assertBool,
@@ -44,6 +50,9 @@ import Test.Tasty.HUnit (
  )
 import Test.Tasty.Runners (timed)
 import Turtle.Prelude (need)
+
+testLogger :: Logger
+testLogger = noLogging
 
 awsMqttConfig :: HostName -> Credential -> CertificateStore -> MQTTConfig
 awsMqttConfig hostName cred certStore =


### PR DESCRIPTION
Added simple logging infrastructure and various log messages. 

A `Logger` type carries a logging function and verbosity and this is passed to functions as needed. This works just fine for now. If the code grows and threading this `Logger` around becomes difficult, then we can look at doing something like using `ReaderT`.

