### PR TITLE
Client Streaming

### DIFF
--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,8 @@
+indentation: 2
+comma-style: leading
+indent-wheres: true
+record-brace-space: false
+diff-friendly-import-export: false
+respectful: true
+haddock-style: multi-line
+newlines-between-decls: 1

--- a/gen/Proto/Mqtt.hs
+++ b/gen/Proto/Mqtt.hs
@@ -1312,9 +1312,8 @@ instance HsJSONPB.ToSchema StreamResponse where
                                                          streamResponseResponseCode),
                                                         ("details", streamResponseDetails)]}})
  
-data WrappedMQTTRequest = WrappedMQTTRequest{wrappedMQTTRequestResponseTopic
-                                             :: Hs.Text,
-                                             wrappedMQTTRequestTimeout :: Hs.Int64,
+data WrappedMQTTRequest = WrappedMQTTRequest{wrappedMQTTRequestTimeout
+                                             :: Hs.Int64,
                                              wrappedMQTTRequestMetamap ::
                                              Hs.Maybe Proto.Mqtt.MetadataMap,
                                              wrappedMQTTRequestPayload :: Hs.ByteString}
@@ -1327,77 +1326,63 @@ instance HsProtobuf.HasDefault WrappedMQTTRequest
  
 instance HsProtobuf.Message WrappedMQTTRequest where
         encodeMessage _
-          WrappedMQTTRequest{wrappedMQTTRequestResponseTopic =
-                               wrappedMQTTRequestResponseTopic,
-                             wrappedMQTTRequestTimeout = wrappedMQTTRequestTimeout,
+          WrappedMQTTRequest{wrappedMQTTRequestTimeout =
+                               wrappedMQTTRequestTimeout,
                              wrappedMQTTRequestMetamap = wrappedMQTTRequestMetamap,
                              wrappedMQTTRequestPayload = wrappedMQTTRequestPayload}
           = (Hs.mconcat
                [(HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
-                   wrappedMQTTRequestResponseTopic),
-                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
                    wrappedMQTTRequestTimeout),
-                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 3)
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
                    (Hs.coerce @(Hs.Maybe Proto.Mqtt.MetadataMap)
                       @(HsProtobuf.Nested Proto.Mqtt.MetadataMap)
                       wrappedMQTTRequestMetamap)),
-                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 4)
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 3)
                    wrappedMQTTRequestPayload)])
         decodeMessage _
           = (Hs.pure WrappedMQTTRequest) <*>
               (HsProtobuf.at HsProtobuf.decodeMessageField
                  (HsProtobuf.FieldNumber 1))
               <*>
-              (HsProtobuf.at HsProtobuf.decodeMessageField
-                 (HsProtobuf.FieldNumber 2))
-              <*>
               (Hs.coerce @(_ (HsProtobuf.Nested Proto.Mqtt.MetadataMap))
                  @(_ (Hs.Maybe Proto.Mqtt.MetadataMap))
                  (HsProtobuf.at HsProtobuf.decodeMessageField
-                    (HsProtobuf.FieldNumber 3)))
+                    (HsProtobuf.FieldNumber 2)))
               <*>
               (HsProtobuf.at HsProtobuf.decodeMessageField
-                 (HsProtobuf.FieldNumber 4))
+                 (HsProtobuf.FieldNumber 3))
         dotProto _
           = [(HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 1)
-                (HsProtobuf.Prim HsProtobuf.String)
-                (HsProtobuf.Single "response_topic")
-                []
-                ""),
-             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 2)
                 (HsProtobuf.Prim HsProtobuf.Int64)
                 (HsProtobuf.Single "timeout")
                 []
                 ""),
-             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 3)
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 2)
                 (HsProtobuf.Prim
                    (HsProtobuf.Named (HsProtobuf.Single "MetadataMap")))
                 (HsProtobuf.Single "metamap")
                 []
                 ""),
-             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 4)
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 3)
                 (HsProtobuf.Prim HsProtobuf.Bytes)
                 (HsProtobuf.Single "payload")
                 []
                 "")]
  
 instance HsJSONPB.ToJSONPB WrappedMQTTRequest where
-        toJSONPB (WrappedMQTTRequest f1 f2 f3 f4)
+        toJSONPB (WrappedMQTTRequest f1 f2 f3)
           = (HsJSONPB.object
-               ["response_topic" .= f1, "timeout" .= f2, "metamap" .= f3,
-                "payload" .= f4])
-        toEncodingPB (WrappedMQTTRequest f1 f2 f3 f4)
+               ["timeout" .= f1, "metamap" .= f2, "payload" .= f3])
+        toEncodingPB (WrappedMQTTRequest f1 f2 f3)
           = (HsJSONPB.pairs
-               ["response_topic" .= f1, "timeout" .= f2, "metamap" .= f3,
-                "payload" .= f4])
+               ["timeout" .= f1, "metamap" .= f2, "payload" .= f3])
  
 instance HsJSONPB.FromJSONPB WrappedMQTTRequest where
         parseJSONPB
           = (HsJSONPB.withObject "WrappedMQTTRequest"
                (\ obj ->
-                  (Hs.pure WrappedMQTTRequest) <*> obj .: "response_topic" <*>
-                    obj .: "timeout"
-                    <*> obj .: "metamap"
+                  (Hs.pure WrappedMQTTRequest) <*> obj .: "timeout" <*>
+                    obj .: "metamap"
                     <*> obj .: "payload"))
  
 instance HsJSONPB.ToJSON WrappedMQTTRequest where
@@ -1409,18 +1394,14 @@ instance HsJSONPB.FromJSON WrappedMQTTRequest where
  
 instance HsJSONPB.ToSchema WrappedMQTTRequest where
         declareNamedSchema _
-          = do let declare_response_topic = HsJSONPB.declareSchemaRef
-               wrappedMQTTRequestResponseTopic <- declare_response_topic
-                                                    Proxy.Proxy
-               let declare_timeout = HsJSONPB.declareSchemaRef
+          = do let declare_timeout = HsJSONPB.declareSchemaRef
                wrappedMQTTRequestTimeout <- declare_timeout Proxy.Proxy
                let declare_metamap = HsJSONPB.declareSchemaRef
                wrappedMQTTRequestMetamap <- declare_metamap Proxy.Proxy
                let declare_payload = HsJSONPB.declareSchemaRef
                wrappedMQTTRequestPayload <- declare_payload Proxy.Proxy
                let _ = Hs.pure WrappedMQTTRequest <*>
-                         HsJSONPB.asProxy declare_response_topic
-                         <*> HsJSONPB.asProxy declare_timeout
+                         HsJSONPB.asProxy declare_timeout
                          <*> HsJSONPB.asProxy declare_metamap
                          <*> HsJSONPB.asProxy declare_payload
                Hs.return
@@ -1432,9 +1413,7 @@ instance HsJSONPB.ToSchema WrappedMQTTRequest where
                                                                  Hs.Just HsJSONPB.SwaggerObject},
                                                    HsJSONPB._schemaProperties =
                                                      HsJSONPB.insOrdFromList
-                                                       [("response_topic",
-                                                         wrappedMQTTRequestResponseTopic),
-                                                        ("timeout", wrappedMQTTRequestTimeout),
+                                                       [("timeout", wrappedMQTTRequestTimeout),
                                                         ("metamap", wrappedMQTTRequestMetamap),
                                                         ("payload", wrappedMQTTRequestPayload)]}})
  

--- a/gen/Proto/Mqtt.hs
+++ b/gen/Proto/Mqtt.hs
@@ -750,6 +750,314 @@ instance HsJSONPB.ToSchema WrappedStreamChunkOrError where
                                                    HsJSONPB._schemaMinProperties = Hs.Just 1,
                                                    HsJSONPB._schemaMaxProperties = Hs.Just 1}})
  
+newtype WrappedClientStreamResponse = WrappedClientStreamResponse{wrappedClientStreamResponseOrError
+                                                                  ::
+                                                                  Hs.Maybe
+                                                                    WrappedClientStreamResponseOrError}
+                                      deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)
+ 
+instance HsProtobuf.Named WrappedClientStreamResponse where
+        nameOf _ = (Hs.fromString "WrappedClientStreamResponse")
+ 
+instance HsProtobuf.HasDefault WrappedClientStreamResponse
+ 
+instance HsProtobuf.Message WrappedClientStreamResponse where
+        encodeMessage _
+          WrappedClientStreamResponse{wrappedClientStreamResponseOrError =
+                                        wrappedClientStreamResponseOrError}
+          = (Hs.mconcat
+               [case wrappedClientStreamResponseOrError of
+                    Hs.Nothing -> Hs.mempty
+                    Hs.Just x
+                      -> case x of
+                             WrappedClientStreamResponseOrErrorResponse y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
+                                     (Hs.coerce @(Hs.Maybe Proto.Mqtt.ClientStreamResponse)
+                                        @(HsProtobuf.Nested Proto.Mqtt.ClientStreamResponse)
+                                        (Hs.Just y)))
+                             WrappedClientStreamResponseOrErrorError y
+                               -> (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
+                                     (Hs.coerce @(Hs.Maybe Proto.Mqtt.RemoteClientError)
+                                        @(HsProtobuf.Nested Proto.Mqtt.RemoteClientError)
+                                        (Hs.Just y)))])
+        decodeMessage _
+          = (Hs.pure WrappedClientStreamResponse) <*>
+              (HsProtobuf.oneof Hs.Nothing
+                 [((HsProtobuf.FieldNumber 1),
+                   (Hs.pure (Hs.fmap WrappedClientStreamResponseOrErrorResponse)) <*>
+                     (Hs.coerce @(_ (HsProtobuf.Nested Proto.Mqtt.ClientStreamResponse))
+                        @(_ (Hs.Maybe Proto.Mqtt.ClientStreamResponse))
+                        HsProtobuf.decodeMessageField)),
+                  ((HsProtobuf.FieldNumber 2),
+                   (Hs.pure (Hs.fmap WrappedClientStreamResponseOrErrorError)) <*>
+                     (Hs.coerce @(_ (HsProtobuf.Nested Proto.Mqtt.RemoteClientError))
+                        @(_ (Hs.Maybe Proto.Mqtt.RemoteClientError))
+                        HsProtobuf.decodeMessageField))])
+        dotProto _ = []
+ 
+instance HsJSONPB.ToJSONPB WrappedClientStreamResponse where
+        toJSONPB (WrappedClientStreamResponse f1_or_f2)
+          = (HsJSONPB.object
+               [(let encodeOr_error
+                       = (case f1_or_f2 of
+                              Hs.Just (WrappedClientStreamResponseOrErrorResponse f1)
+                                -> (HsJSONPB.pair "response" f1)
+                              Hs.Just (WrappedClientStreamResponseOrErrorError f2)
+                                -> (HsJSONPB.pair "error" f2)
+                              Hs.Nothing -> Hs.mempty)
+                   in
+                   \ options ->
+                     if HsJSONPB.optEmitNamedOneof options then
+                       ("or_error" .= (HsJSONPB.objectOrNull [encodeOr_error] options))
+                         options
+                       else encodeOr_error options)])
+        toEncodingPB (WrappedClientStreamResponse f1_or_f2)
+          = (HsJSONPB.pairs
+               [(let encodeOr_error
+                       = (case f1_or_f2 of
+                              Hs.Just (WrappedClientStreamResponseOrErrorResponse f1)
+                                -> (HsJSONPB.pair "response" f1)
+                              Hs.Just (WrappedClientStreamResponseOrErrorError f2)
+                                -> (HsJSONPB.pair "error" f2)
+                              Hs.Nothing -> Hs.mempty)
+                   in
+                   \ options ->
+                     if HsJSONPB.optEmitNamedOneof options then
+                       ("or_error" .= (HsJSONPB.pairsOrNull [encodeOr_error] options))
+                         options
+                       else encodeOr_error options)])
+ 
+instance HsJSONPB.FromJSONPB WrappedClientStreamResponse where
+        parseJSONPB
+          = (HsJSONPB.withObject "WrappedClientStreamResponse"
+               (\ obj ->
+                  (Hs.pure WrappedClientStreamResponse) <*>
+                    (let parseOr_error parseObj
+                           = Hs.msum
+                               [Hs.Just Hs.. WrappedClientStreamResponseOrErrorResponse <$>
+                                  (HsJSONPB.parseField parseObj "response"),
+                                Hs.Just Hs.. WrappedClientStreamResponseOrErrorError <$>
+                                  (HsJSONPB.parseField parseObj "error"),
+                                Hs.pure Hs.Nothing]
+                       in
+                       ((obj .: "or_error") Hs.>>=
+                          (HsJSONPB.withObject "or_error" parseOr_error))
+                         <|> (parseOr_error obj))))
+ 
+instance HsJSONPB.ToJSON WrappedClientStreamResponse where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsJSONPB.FromJSON WrappedClientStreamResponse where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema WrappedClientStreamResponse where
+        declareNamedSchema _
+          = do let declare_or_error = HsJSONPB.declareSchemaRef
+               wrappedClientStreamResponseOrError <- declare_or_error Proxy.Proxy
+               let _ = Hs.pure WrappedClientStreamResponse <*>
+                         HsJSONPB.asProxy declare_or_error
+               Hs.return
+                 (HsJSONPB.NamedSchema{HsJSONPB._namedSchemaName =
+                                         Hs.Just "WrappedClientStreamResponse",
+                                       HsJSONPB._namedSchemaSchema =
+                                         Hs.mempty{HsJSONPB._schemaParamSchema =
+                                                     Hs.mempty{HsJSONPB._paramSchemaType =
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
+                                                   HsJSONPB._schemaProperties =
+                                                     HsJSONPB.insOrdFromList
+                                                       [("or_error",
+                                                         wrappedClientStreamResponseOrError)]}})
+ 
+data WrappedClientStreamResponseOrError = WrappedClientStreamResponseOrErrorResponse Proto.Mqtt.ClientStreamResponse
+                                        | WrappedClientStreamResponseOrErrorError Proto.Mqtt.RemoteClientError
+                                        deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)
+ 
+instance HsProtobuf.Named WrappedClientStreamResponseOrError where
+        nameOf _ = (Hs.fromString "WrappedClientStreamResponseOrError")
+ 
+instance HsJSONPB.ToSchema WrappedClientStreamResponseOrError where
+        declareNamedSchema _
+          = do let declare_response = HsJSONPB.declareSchemaRef
+               wrappedClientStreamResponseOrErrorResponse <- declare_response
+                                                               Proxy.Proxy
+               let _ = Hs.pure WrappedClientStreamResponseOrErrorResponse <*>
+                         HsJSONPB.asProxy declare_response
+               let declare_error = HsJSONPB.declareSchemaRef
+               wrappedClientStreamResponseOrErrorError <- declare_error
+                                                            Proxy.Proxy
+               let _ = Hs.pure WrappedClientStreamResponseOrErrorError <*>
+                         HsJSONPB.asProxy declare_error
+               Hs.return
+                 (HsJSONPB.NamedSchema{HsJSONPB._namedSchemaName =
+                                         Hs.Just "WrappedClientStreamResponseOrError",
+                                       HsJSONPB._namedSchemaSchema =
+                                         Hs.mempty{HsJSONPB._schemaParamSchema =
+                                                     Hs.mempty{HsJSONPB._paramSchemaType =
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
+                                                   HsJSONPB._schemaProperties =
+                                                     HsJSONPB.insOrdFromList
+                                                       [("response",
+                                                         wrappedClientStreamResponseOrErrorResponse),
+                                                        ("error",
+                                                         wrappedClientStreamResponseOrErrorError)],
+                                                   HsJSONPB._schemaMinProperties = Hs.Just 1,
+                                                   HsJSONPB._schemaMaxProperties = Hs.Just 1}})
+ 
+data ClientStreamResponse = ClientStreamResponse{clientStreamResponseBody
+                                                 :: Hs.ByteString,
+                                                 clientStreamResponseInitMetamap ::
+                                                 Hs.Maybe Proto.Mqtt.MetadataMap,
+                                                 clientStreamResponseTrailMetamap ::
+                                                 Hs.Maybe Proto.Mqtt.MetadataMap,
+                                                 clientStreamResponseResponseCode :: Hs.Int32,
+                                                 clientStreamResponseDetails :: Hs.Text}
+                          deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)
+ 
+instance HsProtobuf.Named ClientStreamResponse where
+        nameOf _ = (Hs.fromString "ClientStreamResponse")
+ 
+instance HsProtobuf.HasDefault ClientStreamResponse
+ 
+instance HsProtobuf.Message ClientStreamResponse where
+        encodeMessage _
+          ClientStreamResponse{clientStreamResponseBody =
+                                 clientStreamResponseBody,
+                               clientStreamResponseInitMetamap = clientStreamResponseInitMetamap,
+                               clientStreamResponseTrailMetamap =
+                                 clientStreamResponseTrailMetamap,
+                               clientStreamResponseResponseCode =
+                                 clientStreamResponseResponseCode,
+                               clientStreamResponseDetails = clientStreamResponseDetails}
+          = (Hs.mconcat
+               [(HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 1)
+                   clientStreamResponseBody),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 2)
+                   (Hs.coerce @(Hs.Maybe Proto.Mqtt.MetadataMap)
+                      @(HsProtobuf.Nested Proto.Mqtt.MetadataMap)
+                      clientStreamResponseInitMetamap)),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 3)
+                   (Hs.coerce @(Hs.Maybe Proto.Mqtt.MetadataMap)
+                      @(HsProtobuf.Nested Proto.Mqtt.MetadataMap)
+                      clientStreamResponseTrailMetamap)),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 4)
+                   clientStreamResponseResponseCode),
+                (HsProtobuf.encodeMessageField (HsProtobuf.FieldNumber 5)
+                   clientStreamResponseDetails)])
+        decodeMessage _
+          = (Hs.pure ClientStreamResponse) <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 1))
+              <*>
+              (Hs.coerce @(_ (HsProtobuf.Nested Proto.Mqtt.MetadataMap))
+                 @(_ (Hs.Maybe Proto.Mqtt.MetadataMap))
+                 (HsProtobuf.at HsProtobuf.decodeMessageField
+                    (HsProtobuf.FieldNumber 2)))
+              <*>
+              (Hs.coerce @(_ (HsProtobuf.Nested Proto.Mqtt.MetadataMap))
+                 @(_ (Hs.Maybe Proto.Mqtt.MetadataMap))
+                 (HsProtobuf.at HsProtobuf.decodeMessageField
+                    (HsProtobuf.FieldNumber 3)))
+              <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 4))
+              <*>
+              (HsProtobuf.at HsProtobuf.decodeMessageField
+                 (HsProtobuf.FieldNumber 5))
+        dotProto _
+          = [(HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 1)
+                (HsProtobuf.Prim HsProtobuf.Bytes)
+                (HsProtobuf.Single "body")
+                []
+                ""),
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 2)
+                (HsProtobuf.Prim
+                   (HsProtobuf.Named (HsProtobuf.Single "MetadataMap")))
+                (HsProtobuf.Single "init_metamap")
+                []
+                ""),
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 3)
+                (HsProtobuf.Prim
+                   (HsProtobuf.Named (HsProtobuf.Single "MetadataMap")))
+                (HsProtobuf.Single "trail_metamap")
+                []
+                ""),
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 4)
+                (HsProtobuf.Prim HsProtobuf.Int32)
+                (HsProtobuf.Single "response_code")
+                []
+                ""),
+             (HsProtobuf.DotProtoField (HsProtobuf.FieldNumber 5)
+                (HsProtobuf.Prim HsProtobuf.String)
+                (HsProtobuf.Single "details")
+                []
+                "")]
+ 
+instance HsJSONPB.ToJSONPB ClientStreamResponse where
+        toJSONPB (ClientStreamResponse f1 f2 f3 f4 f5)
+          = (HsJSONPB.object
+               ["body" .= f1, "init_metamap" .= f2, "trail_metamap" .= f3,
+                "response_code" .= f4, "details" .= f5])
+        toEncodingPB (ClientStreamResponse f1 f2 f3 f4 f5)
+          = (HsJSONPB.pairs
+               ["body" .= f1, "init_metamap" .= f2, "trail_metamap" .= f3,
+                "response_code" .= f4, "details" .= f5])
+ 
+instance HsJSONPB.FromJSONPB ClientStreamResponse where
+        parseJSONPB
+          = (HsJSONPB.withObject "ClientStreamResponse"
+               (\ obj ->
+                  (Hs.pure ClientStreamResponse) <*> obj .: "body" <*>
+                    obj .: "init_metamap"
+                    <*> obj .: "trail_metamap"
+                    <*> obj .: "response_code"
+                    <*> obj .: "details"))
+ 
+instance HsJSONPB.ToJSON ClientStreamResponse where
+        toJSON = HsJSONPB.toAesonValue
+        toEncoding = HsJSONPB.toAesonEncoding
+ 
+instance HsJSONPB.FromJSON ClientStreamResponse where
+        parseJSON = HsJSONPB.parseJSONPB
+ 
+instance HsJSONPB.ToSchema ClientStreamResponse where
+        declareNamedSchema _
+          = do let declare_body = HsJSONPB.declareSchemaRef
+               clientStreamResponseBody <- declare_body Proxy.Proxy
+               let declare_init_metamap = HsJSONPB.declareSchemaRef
+               clientStreamResponseInitMetamap <- declare_init_metamap Proxy.Proxy
+               let declare_trail_metamap = HsJSONPB.declareSchemaRef
+               clientStreamResponseTrailMetamap <- declare_trail_metamap
+                                                     Proxy.Proxy
+               let declare_response_code = HsJSONPB.declareSchemaRef
+               clientStreamResponseResponseCode <- declare_response_code
+                                                     Proxy.Proxy
+               let declare_details = HsJSONPB.declareSchemaRef
+               clientStreamResponseDetails <- declare_details Proxy.Proxy
+               let _ = Hs.pure ClientStreamResponse <*>
+                         HsJSONPB.asProxy declare_body
+                         <*> HsJSONPB.asProxy declare_init_metamap
+                         <*> HsJSONPB.asProxy declare_trail_metamap
+                         <*> HsJSONPB.asProxy declare_response_code
+                         <*> HsJSONPB.asProxy declare_details
+               Hs.return
+                 (HsJSONPB.NamedSchema{HsJSONPB._namedSchemaName =
+                                         Hs.Just "ClientStreamResponse",
+                                       HsJSONPB._namedSchemaSchema =
+                                         Hs.mempty{HsJSONPB._schemaParamSchema =
+                                                     Hs.mempty{HsJSONPB._paramSchemaType =
+                                                                 Hs.Just HsJSONPB.SwaggerObject},
+                                                   HsJSONPB._schemaProperties =
+                                                     HsJSONPB.insOrdFromList
+                                                       [("body", clientStreamResponseBody),
+                                                        ("init_metamap",
+                                                         clientStreamResponseInitMetamap),
+                                                        ("trail_metamap",
+                                                         clientStreamResponseTrailMetamap),
+                                                        ("response_code",
+                                                         clientStreamResponseResponseCode),
+                                                        ("details", clientStreamResponseDetails)]}})
+ 
 newtype WrappedStreamResponse = WrappedStreamResponse{wrappedStreamResponseOrError
                                                       :: Hs.Maybe WrappedStreamResponseOrError}
                                 deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)

--- a/gen/Proto/Test.hs
+++ b/gen/Proto/Test.hs
@@ -49,7 +49,13 @@ data AddHello request response = AddHello{addHelloAdd ::
                                             Proto.Test.SSRpy
                                             ->
                                             Hs.IO
-                                              (response 'HsGRPC.ServerStreaming Proto.Test.SSRpy)}
+                                              (response 'HsGRPC.ServerStreaming Proto.Test.SSRpy),
+                                          addHelloRunningSum ::
+                                          request 'HsGRPC.ClientStreaming Proto.Test.OneInt
+                                            Proto.Test.OneInt
+                                            ->
+                                            Hs.IO
+                                              (response 'HsGRPC.ClientStreaming Proto.Test.OneInt)}
                                deriving Hs.Generic
  
 addHelloServer ::
@@ -57,7 +63,8 @@ addHelloServer ::
                    HsGRPC.ServiceOptions -> Hs.IO ()
 addHelloServer
   AddHello{addHelloAdd = addHelloAdd,
-           addHelloHelloSS = addHelloHelloSS}
+           addHelloHelloSS = addHelloHelloSS,
+           addHelloRunningSum = addHelloRunningSum}
   (ServiceOptions serverHost serverPort useCompression
      userAgentPrefix userAgentSuffix initialMetadata sslConfig logger
      serverMaxReceiveMessageLength)
@@ -65,7 +72,11 @@ addHelloServer
        HsGRPC.defaultOptions{HsGRPC.optNormalHandlers =
                                [(HsGRPC.UnaryHandler (HsGRPC.MethodName "/test.AddHello/Add")
                                    (HsGRPC.convertGeneratedServerHandler addHelloAdd))],
-                             HsGRPC.optClientStreamHandlers = [],
+                             HsGRPC.optClientStreamHandlers =
+                               [(HsGRPC.ClientStreamHandler
+                                   (HsGRPC.MethodName "/test.AddHello/RunningSum")
+                                   (HsGRPC.convertGeneratedServerReaderHandler
+                                      addHelloRunningSum))],
                              HsGRPC.optServerStreamHandlers =
                                [(HsGRPC.ServerStreamHandler
                                    (HsGRPC.MethodName "/test.AddHello/HelloSS")
@@ -90,6 +101,10 @@ addHelloClient client
       ((Hs.pure (HsGRPC.clientRequest client)) <*>
          (HsGRPC.clientRegisterMethod client
             (HsGRPC.MethodName "/test.AddHello/HelloSS")))
+      <*>
+      ((Hs.pure (HsGRPC.clientRequest client)) <*>
+         (HsGRPC.clientRegisterMethod client
+            (HsGRPC.MethodName "/test.AddHello/RunningSum")))
  
 data MultGoodbye request response = MultGoodbye{multGoodbyeMult ::
                                                 request 'HsGRPC.Normal Proto.Test.TwoInts
@@ -102,7 +117,14 @@ data MultGoodbye request response = MultGoodbye{multGoodbyeMult ::
                                                   ->
                                                   Hs.IO
                                                     (response 'HsGRPC.ServerStreaming
-                                                       Proto.Test.SSRpy)}
+                                                       Proto.Test.SSRpy),
+                                                multGoodbyeRunningProd ::
+                                                request 'HsGRPC.ClientStreaming Proto.Test.OneInt
+                                                  Proto.Test.OneInt
+                                                  ->
+                                                  Hs.IO
+                                                    (response 'HsGRPC.ClientStreaming
+                                                       Proto.Test.OneInt)}
                                   deriving Hs.Generic
  
 multGoodbyeServer ::
@@ -110,7 +132,8 @@ multGoodbyeServer ::
                       HsGRPC.ServiceOptions -> Hs.IO ()
 multGoodbyeServer
   MultGoodbye{multGoodbyeMult = multGoodbyeMult,
-              multGoodbyeGoodbyeSS = multGoodbyeGoodbyeSS}
+              multGoodbyeGoodbyeSS = multGoodbyeGoodbyeSS,
+              multGoodbyeRunningProd = multGoodbyeRunningProd}
   (ServiceOptions serverHost serverPort useCompression
      userAgentPrefix userAgentSuffix initialMetadata sslConfig logger
      serverMaxReceiveMessageLength)
@@ -118,7 +141,11 @@ multGoodbyeServer
        HsGRPC.defaultOptions{HsGRPC.optNormalHandlers =
                                [(HsGRPC.UnaryHandler (HsGRPC.MethodName "/test.MultGoodbye/Mult")
                                    (HsGRPC.convertGeneratedServerHandler multGoodbyeMult))],
-                             HsGRPC.optClientStreamHandlers = [],
+                             HsGRPC.optClientStreamHandlers =
+                               [(HsGRPC.ClientStreamHandler
+                                   (HsGRPC.MethodName "/test.MultGoodbye/RunningProd")
+                                   (HsGRPC.convertGeneratedServerReaderHandler
+                                      multGoodbyeRunningProd))],
                              HsGRPC.optServerStreamHandlers =
                                [(HsGRPC.ServerStreamHandler
                                    (HsGRPC.MethodName "/test.MultGoodbye/GoodbyeSS")
@@ -144,6 +171,10 @@ multGoodbyeClient client
       ((Hs.pure (HsGRPC.clientRequest client)) <*>
          (HsGRPC.clientRegisterMethod client
             (HsGRPC.MethodName "/test.MultGoodbye/GoodbyeSS")))
+      <*>
+      ((Hs.pure (HsGRPC.clientRequest client)) <*>
+         (HsGRPC.clientRegisterMethod client
+            (HsGRPC.MethodName "/test.MultGoodbye/RunningProd")))
  
 data TwoInts = TwoInts{twoIntsX :: Hs.Int32, twoIntsY :: Hs.Int32}
              deriving (Hs.Show, Hs.Eq, Hs.Ord, Hs.Generic, Hs.NFData)

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -89,6 +89,7 @@ library
   build-depends:      base64
                     , conduit-extra
                     , connection
+                    , mtl
                     , network-conduit-tls
                     , nonce
                     , sorted-list

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -89,7 +89,6 @@ library
   build-depends:      base64
                     , conduit-extra
                     , connection
-                    , mtl
                     , network-conduit-tls
                     , nonce
                     , sorted-list

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -61,7 +61,7 @@ common shared-settings
                     , deepseq
                     , grpc-haskell
                     , grpc-haskell-core
-                    , net-mqtt >= 0.8
+                    , net-mqtt >= 0.8.1
                     , proto3-suite
                     , proto3-wire
                     , relude

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -16,11 +16,16 @@ let
   proto-files = ../../proto;
 
 in {
+  all-cabal-hashes = pkgsOld.fetchurl {
+    url = "https://github.com/commercialhaskell/all-cabal-hashes/archive/946958a82b6c589393f3ba9234345ac3f2d3d512.tar.gz";
+    sha256 = "00d296y7lxsfplbrhcyr7wp8cymh7zhf0q59ia1kxrly40v47fkr";
+  };
+
   haskellPackages = pkgsOld.haskell.packages."${compiler}".override (old: {
     overrides = pkgsNew.lib.composeExtensions
       (old.overrides or (_: _: { }))
       (haskellPackagesNew: haskellPackagesOld: {
-        net-mqtt = haskellPackagesNew.callHackage "net-mqtt" "0.8.0.2";
+        net-mqtt = haskellPackagesNew.callHackage "net-mqtt" "0.8.1.0" {};
 
         range-set-list =
           pkgsNew.haskell.lib.overrideCabal

--- a/proto/mqtt.proto
+++ b/proto/mqtt.proto
@@ -62,6 +62,21 @@ message WrappedStreamChunk {
   }
 }
 
+message WrappedClientStreamResponse {
+  oneof or_error {
+    ClientStreamResponse response = 1;
+    RemoteClientError error = 2;
+  }
+}
+
+message ClientStreamResponse {
+  bytes body = 1;
+  MetadataMap init_metamap = 2;
+  MetadataMap trail_metamap = 3;
+  int32 response_code = 4;
+  string details = 5;
+}
+
 message WrappedStreamResponse {
   oneof or_error {
     StreamResponse response = 1;

--- a/proto/mqtt.proto
+++ b/proto/mqtt.proto
@@ -91,10 +91,9 @@ message StreamResponse {
 }
 
 message WrappedMQTTRequest {
-  string response_topic = 1;
-  int64 timeout = 2;
-  MetadataMap metamap = 3;
-  bytes payload = 4;
+  int64 timeout = 1;
+  MetadataMap metamap = 2;
+  bytes payload = 3;
 }
 
 message WrappedUnaryResponse {

--- a/proto/test.proto
+++ b/proto/test.proto
@@ -7,6 +7,9 @@ service AddHello {
 
   /* Server Streaming Service */
   rpc HelloSS(SSRqt) returns (stream SSRpy) {}
+
+  /* Client Streaming Service */
+  rpc RunningSum (stream OneInt) returns (OneInt) {}
 }
 
 service MultGoodbye {
@@ -15,6 +18,9 @@ service MultGoodbye {
 
   /* Server Streaming Service */
   rpc GoodbyeSS(SSRqt) returns (stream SSRpy) {}
+
+  /* Client Streaming Service */
+  rpc RunningProd (stream OneInt) returns (OneInt) {}
 }
 
 message TwoInts {

--- a/src/Network/GRPC/MQTT.hs
+++ b/src/Network/GRPC/MQTT.hs
@@ -6,7 +6,8 @@
 
 module Network.GRPC.MQTT
   ( -- * Re-exports from 'net-mqtt'
-    Topic (..),
+    Topic (unTopic),
+    mkTopic,
     MQTTException (..),
     ProtocolLevel (..),
     Property (..),

--- a/src/Network/GRPC/MQTT.hs
+++ b/src/Network/GRPC/MQTT.hs
@@ -1,11 +1,18 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
 
-module Network.GRPC.MQTT (
-  module Network.MQTT.Client
-)where
+module Network.GRPC.MQTT
+  ( -- * Re-exports from 'net-mqtt'
+    Topic (..),
+    MQTTException (..),
+    ProtocolLevel (..),
+    Property (..),
+    LastWill (..),
+  )
+where
 
 import Network.MQTT.Client
+import Network.MQTT.Topic

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -166,7 +166,7 @@ mqttRequest MQTTGRPCClient{..} baseTopic (MethodName method) request = do
               logDebug mqttLogger $ "Publishing stream chunk to topic: " <> unTopic requestTopic
               let wrappedReq = wrapStreamChunk (Just req)
               publishReq wrappedReq
-              -- TODO: Fix this. Send errors won't be propegated to client's send handler
+              -- TODO: Fix this. Send errors won't be propagated to client's send handler
               return $ Right ()
 
         grpcTimeout timeLimit $ do

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -233,7 +233,7 @@ withControlSignals publishControlMsg = withMQTTHeartbeat . sendTerminateOnExcept
 {- | Connects to the MQTT broker and creates a 'MQTTGRPCClient'
  NB: Overwrites the '_msgCB' field in the 'MQTTConfig'
 -}
-connectMQTTGRPC :: (MonadIO m) => Logger -> MQTTGRPCConfig -> m MQTTGRPCClient
+connectMQTTGRPC :: (MonadIO io) => Logger -> MQTTGRPCConfig -> io MQTTGRPCClient
 connectMQTTGRPC logger cfg = do
   resultChan <- newTChanIO
 

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -95,7 +95,7 @@ getMQTTConfig :: MQTTGRPCConfig -> MQTTConfig
 getMQTTConfig MQTTGRPCConfig{..} = MQTTConfig{..}
 
 -- | Connect to an MQTT broker
-connectMQTT :: MonadIO m => MQTTGRPCConfig -> m MQTTClient
+connectMQTT :: (MonadIO io) => MQTTGRPCConfig -> io MQTTClient
 connectMQTT cfg@MQTTGRPCConfig{..} = liftIO $ do
   let runner = if useTLS then runTLS else runTCP
   runMQTTConduit runner (getMQTTConfig cfg)

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -10,7 +10,6 @@ module Network.GRPC.MQTT.Core
   ( MQTTGRPCConfig (..),
     connectMQTT,
     heartbeatPeriodSeconds,
-    toFilter,
     defaultMGConfig,
     subscribeOrThrow,
   )
@@ -46,9 +45,8 @@ import Network.MQTT.Client
     subOptions,
     subscribe,
   )
-import Network.MQTT.Topic (Filter (unFilter), Topic (unTopic), mkFilter)
+import Network.MQTT.Topic (Filter(unFilter))
 import Network.MQTT.Types (LastWill, Property, ProtocolLevel (Protocol311), SubErr)
-import Relude.Unsafe (fromJust)
 import Turtle (NominalDiffTime)
 
 {- |
@@ -120,13 +118,6 @@ connectMQTT cfg@MQTTGRPCConfig{..} = liftIO $ do
 -- | Period for heartbeat messages
 heartbeatPeriodSeconds :: NominalDiffTime
 heartbeatPeriodSeconds = 10
-
-{- | Topics are strictly a subset of 'Filter's so this conversion is always safe
- | This is a bit of a hack, but there is a upstream PR to add this to the net-mqtt
- | library: https://github.com/dustin/mqtt-hs/pull/22
--}
-toFilter :: Topic -> Filter
-toFilter = fromJust . mkFilter . unTopic
 
 subscribeOrThrow :: MQTTClient -> [Filter] -> IO ()
 subscribeOrThrow client topics = do

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -23,14 +23,14 @@ data Verbosity
 noLogging :: Logger
 noLogging = Logger (\_ -> pure ()) Silent
 
-logErr :: Logger -> Text -> IO ()
+logErr :: (MonadIO m) => Logger -> Text -> m ()
 logErr = logVerbosity Error
-logWarn :: Logger -> Text -> IO ()
+logWarn :: (MonadIO m) => Logger -> Text -> m ()
 logWarn = logVerbosity Warn
-logInfo :: Logger -> Text -> IO ()
+logInfo :: (MonadIO m) => Logger -> Text -> m ()
 logInfo = logVerbosity Info
-logDebug :: Logger -> Text -> IO ()
+logDebug :: (MonadIO m) => Logger -> Text -> m ()
 logDebug = logVerbosity Debug
 
-logVerbosity :: Verbosity -> Logger -> Text -> IO ()
-logVerbosity v logger msg = when (verbosity logger >= v) $ log logger msg
+logVerbosity :: (MonadIO m) => Verbosity -> Logger -> Text -> m ()
+logVerbosity v logger msg = when (verbosity logger >= v) $ liftIO (log logger msg)

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -23,14 +23,14 @@ data Verbosity
 noLogging :: Logger
 noLogging = Logger (\_ -> pure ()) Silent
 
-logErr :: (MonadIO m) => Logger -> Text -> m ()
+logErr :: (MonadIO io) => Logger -> Text -> io ()
 logErr = logVerbosity Error
-logWarn :: (MonadIO m) => Logger -> Text -> m ()
+logWarn :: (MonadIO io) => Logger -> Text -> io ()
 logWarn = logVerbosity Warn
-logInfo :: (MonadIO m) => Logger -> Text -> m ()
+logInfo :: (MonadIO io) => Logger -> Text -> io ()
 logInfo = logVerbosity Info
-logDebug :: (MonadIO m) => Logger -> Text -> m ()
+logDebug :: (MonadIO io) => Logger -> Text -> io ()
 logDebug = logVerbosity Debug
 
-logVerbosity :: (MonadIO m) => Verbosity -> Logger -> Text -> m ()
+logVerbosity :: (MonadIO io) => Verbosity -> Logger -> Text -> io ()
 logVerbosity v logger msg = when (verbosity logger >= v) $ liftIO (log logger msg)

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -1,42 +1,42 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE TemplateHaskell #-}
 
-module Network.GRPC.MQTT.TH.Client (
-  mqttClientFuncs,
-  mqttRequest,
-  MethodName (MethodName),
-) where
+module Network.GRPC.MQTT.TH.Client
+  ( mqttClientFuncs,
+    mqttRequest,
+    MethodName (MethodName),
+  )
+where
 
 import Relude hiding (FilePath)
 
 import Network.GRPC.MQTT.TH.Proto (forEachService)
 
-import Language.Haskell.TH (
-  Dec,
-  DecsQ,
-  Name,
-  Q,
-  appE,
-  clause,
-  conE,
-  conT,
-  funD,
-  mkName,
-  normalB,
-  sigD,
-  varE,
-  varP,
- )
+import Language.Haskell.TH
+  ( Dec,
+    DecsQ,
+    Name,
+    Q,
+    appE,
+    clause,
+    conE,
+    conT,
+    funD,
+    mkName,
+    normalB,
+    sigD,
+    varE,
+    varP,
+  )
 import Network.GRPC.HighLevel (MethodName (MethodName))
-import Network.GRPC.MQTT.Client (
-  MQTTGRPCClient,
-  mqttRequest,
- )
+import Network.GRPC.MQTT.Client
+  ( MQTTGRPCClient,
+    mqttRequest,
+  )
 import Network.GRPC.MQTT.Types (MQTTRequest, MQTTResult)
 import Network.MQTT.Topic (Topic)
 import Proto3.Suite.DotProto.Internal (prefixedFieldName)
@@ -53,14 +53,14 @@ clientService fname serviceName methods = do
   fSig <- sigD fname [t|MQTTGRPCClient -> Topic -> $(conT serviceName) MQTTRequest MQTTResult|]
   fDef <- funD fname [clause args (normalB mqttClientE) []]
   return [fSig, fDef]
- where
-  clientName = mkName "client"
-  clientE = varE clientName
-  topicName = mkName "baseTopic"
-  topicE = varE topicName
-  args = [varP clientName, varP topicName]
+  where
+    clientName = mkName "client"
+    clientE = varE clientName
+    topicName = mkName "baseTopic"
+    topicE = varE topicName
+    args = [varP clientName, varP topicName]
 
-  methodNames = fmap (\ep -> [e|MethodName ep|]) methods
-  mqttRequestE methodName = [e|(mqttRequest $clientE $topicE $methodName)|]
-  clientMethods = mqttRequestE <$> methodNames
-  mqttClientE = foldl' appE (conE serviceName) clientMethods
+    methodNames = fmap (\ep -> [e|MethodName ep|]) methods
+    mqttRequestE methodName = [e|(mqttRequest $clientE $topicE $methodName)|]
+    clientMethods = mqttRequestE <$> methodNames
+    mqttClientE = foldl' appE (conE serviceName) clientMethods

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -11,73 +11,71 @@ module Network.GRPC.MQTT.TH.Proto where
 
 import Relude hiding (FilePath)
 
-import Network.GRPC.MQTT.Wrapping (
-  wrapClientStreamingClientHandler,
-  wrapServerStreamingClientHandler,
-  wrapUnaryClientHandler,
- )
+import Network.GRPC.MQTT.Wrapping
+  ( wrapClientStreamingClientHandler,
+    wrapServerStreamingClientHandler,
+    wrapUnaryClientHandler,
+  )
 
 import Language.Haskell.TH (Name, Q, mkName)
-import Proto3.Suite.DotProto.AST (
-  DotProto (protoDefinitions, protoPackage),
-  DotProtoDefinition (DotProtoService),
-  DotProtoIdentifier (Single),
-  DotProtoServicePart (DotProtoServiceRPCMethod),
-  RPCMethod (
-    RPCMethod,
-    rpcMethodName,
-    rpcMethodOptions,
-    rpcMethodRequestStreaming,
-    rpcMethodRequestType,
-    rpcMethodResponseStreaming,
-    rpcMethodResponseType
-  ),
-  Streaming (NonStreaming, Streaming),
- )
-import Proto3.Suite.DotProto.Internal (
-  CompileError,
-  dpIdentQualName,
-  dpIdentUnqualName,
-  importProto,
-  invalidMethodNameError,
-  prefixedFieldName,
-  protoPackageName,
-  typeLikeName,
-  _unimplementedError,
- )
+import Proto3.Suite.DotProto.AST
+  ( DotProto (protoDefinitions, protoPackage),
+    DotProtoDefinition (DotProtoService),
+    DotProtoIdentifier (Single),
+    DotProtoServicePart (DotProtoServiceRPCMethod),
+    RPCMethod
+      ( RPCMethod,
+        rpcMethodName,
+        rpcMethodOptions,
+        rpcMethodRequestStreaming,
+        rpcMethodRequestType,
+        rpcMethodResponseStreaming,
+        rpcMethodResponseType
+      ),
+    Streaming (NonStreaming, Streaming),
+  )
+import Proto3.Suite.DotProto.Internal
+  ( CompileError,
+    dpIdentQualName,
+    dpIdentUnqualName,
+    importProto,
+    invalidMethodNameError,
+    prefixedFieldName,
+    protoPackageName,
+    typeLikeName,
+    _unimplementedError,
+  )
 import Turtle (FilePath, directory, filename)
 
 forEachService :: FilePath -> (String -> [(String, Name, Name)] -> ExceptT CompileError Q a) -> Q [a]
-forEachService protoFilepath action =
-  either (fail . show) pure
-    =<< runExceptT
-      ( do
-          let protoFile = filename protoFilepath
-              protoDir = directory protoFilepath
+forEachService protoFilepath action = showErrors . runExceptT $ do
+  let protoFile = filename protoFilepath
+      protoDir = directory protoFilepath
 
-          dotproto <- importProto [protoDir] protoFile protoFile
-          packageName <- dpIdentQualName =<< protoPackageName (protoPackage dotproto)
+  dotproto <- importProto [protoDir] protoFile protoFile
+  packageName <- dpIdentQualName =<< protoPackageName (protoPackage dotproto)
 
-          let services = [(name, parts) | DotProtoService _ name parts <- protoDefinitions dotproto]
+  let services = [(name, parts) | DotProtoService _ name parts <- protoDefinitions dotproto]
 
-          forM services $ \(name, parts) -> do
-            serviceName <- typeLikeName =<< dpIdentUnqualName name
-            let endpointPrefix = "/" <> packageName <> "." <> serviceName <> "/"
+  forM services $ \(name, parts) -> do
+    serviceName <- typeLikeName =<< dpIdentUnqualName name
+    let endpointPrefix = "/" <> packageName <> "." <> serviceName <> "/"
 
-            let serviceMethodName (DotProtoServiceRPCMethod RPCMethod{..}) = do
-                  case rpcMethodName of
-                    Single nm -> do
-                      streamingWrapper <-
-                        case (rpcMethodRequestStreaming, rpcMethodResponseStreaming) of
-                          (NonStreaming, Streaming) -> pure 'wrapServerStreamingClientHandler
-                          (NonStreaming, NonStreaming) -> pure 'wrapUnaryClientHandler
-                          (Streaming, NonStreaming) -> pure 'wrapClientStreamingClientHandler
-                          _ -> _unimplementedError "Bidirectional streaming not supported"
-                      clientFun <- prefixedFieldName serviceName nm
-                      return [(endpointPrefix <> nm, streamingWrapper, mkName clientFun)]
-                    _ -> invalidMethodNameError rpcMethodName
-                serviceMethodName _ = pure []
+    let serviceMethodName (DotProtoServiceRPCMethod RPCMethod{..}) = do
+          case rpcMethodName of
+            Single nm -> do
+              streamingWrapper <-
+                case (rpcMethodRequestStreaming, rpcMethodResponseStreaming) of
+                  (NonStreaming, Streaming) -> pure 'wrapServerStreamingClientHandler
+                  (NonStreaming, NonStreaming) -> pure 'wrapUnaryClientHandler
+                  (Streaming, NonStreaming) -> pure 'wrapClientStreamingClientHandler
+                  (Streaming, Streaming) -> _unimplementedError "Bidirectional streaming not supported"
+              clientFun <- prefixedFieldName serviceName nm
+              return [(endpointPrefix <> nm, streamingWrapper, mkName clientFun)]
+            _ -> invalidMethodNameError rpcMethodName
+        serviceMethodName _ = pure []
 
-            serviceMethods <- foldMapM serviceMethodName parts
-            action serviceName serviceMethods
-      )
+    serviceMethods <- foldMapM serviceMethodName parts
+    action serviceName serviceMethods
+  where
+    showErrors = fmap (either (fail . show) id)

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -1,9 +1,8 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -12,7 +11,11 @@ module Network.GRPC.MQTT.TH.Proto where
 
 import Relude hiding (FilePath)
 
-import Network.GRPC.MQTT.Wrapping (wrapServerStreamingClientHandler, wrapUnaryClientHandler)
+import Network.GRPC.MQTT.Wrapping (
+  wrapClientStreamingClientHandler,
+  wrapServerStreamingClientHandler,
+  wrapUnaryClientHandler,
+ )
 
 import Language.Haskell.TH (Name, Q, mkName)
 import Proto3.Suite.DotProto.AST (
@@ -68,7 +71,8 @@ forEachService protoFilepath action =
                         case (rpcMethodRequestStreaming, rpcMethodResponseStreaming) of
                           (NonStreaming, Streaming) -> pure 'wrapServerStreamingClientHandler
                           (NonStreaming, NonStreaming) -> pure 'wrapUnaryClientHandler
-                          _ -> _unimplementedError "Client streaming not supported"
+                          (Streaming, NonStreaming) -> pure 'wrapClientStreamingClientHandler
+                          _ -> _unimplementedError "Bidirectional streaming not supported"
                       clientFun <- prefixedFieldName serviceName nm
                       return [(endpointPrefix <> nm, streamingWrapper, mkName clientFun)]
                     _ -> invalidMethodNameError rpcMethodName

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -1,37 +1,37 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE TemplateHaskell #-}
 
-module Network.GRPC.MQTT.TH.RemoteClient (
-  mqttRemoteClientMethodMap,
-  Client,
-  MethodMap,
-  wrapServerStreamingClientHandler,
-  wrapUnaryClientHandler,
-) where
+module Network.GRPC.MQTT.TH.RemoteClient
+  ( mqttRemoteClientMethodMap,
+    Client,
+    MethodMap,
+    wrapServerStreamingClientHandler,
+    wrapUnaryClientHandler,
+  )
+where
 
 import Relude hiding (FilePath)
 
 import Network.GRPC.MQTT.TH.Proto (forEachService)
 
-import Language.Haskell.TH (
-  Dec,
-  DecsQ,
-  Name,
-  Q,
-  clause,
-  funD,
-  listE,
-  mkName,
-  normalB,
-  sigD,
-  varE,
-  varP,
- )
+import Language.Haskell.TH
+  ( Dec,
+    DecsQ,
+    Name,
+    Q,
+    clause,
+    funD,
+    listE,
+    mkName,
+    normalB,
+    sigD,
+    varE,
+    varP,
+  )
 import Network.GRPC.HighLevel.Client (Client)
 import Network.GRPC.MQTT.Types (MethodMap)
 import Network.GRPC.MQTT.Wrapping (wrapServerStreamingClientHandler, wrapUnaryClientHandler)
@@ -50,18 +50,18 @@ rcMethodMap fname grpcName methods = do
   fSig <- sigD fname [t|Client -> IO MethodMap|]
   fDef <- funD fname [clause args (normalB methodMapE) []]
   return [fSig, fDef]
- where
-  clientName = mkName "grpcClient"
-  clientE = varE clientName
-  args = [varP clientName]
-  clientVarName = mkName "client"
-  methodPairs =
-    fmap
-      (\(method, wrapFun, clientFun) -> [e|(method, $(varE wrapFun) ($(varE clientFun) $(varE clientVarName)))|])
-      methods
-  methodMapE =
-    [e|
-      do
-        $(varP clientVarName) <- $(varE grpcName) $clientE
-        return $ fromList $(listE methodPairs)
-      |]
+  where
+    clientName = mkName "grpcClient"
+    clientE = varE clientName
+    args = [varP clientName]
+    clientVarName = mkName "client"
+    methodPairs =
+      fmap
+        (\(method, wrapFun, clientFun) -> [e|(method, $(varE wrapFun) ($(varE clientFun) $(varE clientVarName)))|])
+        methods
+    methodMapE =
+      [e|
+        do
+          $(varP clientVarName) <- $(varE grpcName) $clientE
+          return $ fromList $(listE methodPairs)
+        |]

--- a/src/Network/GRPC/MQTT/Types.hs
+++ b/src/Network/GRPC/MQTT/Types.hs
@@ -1,28 +1,30 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Network.GRPC.MQTT.Types (
-  MQTTResult (..),
-  MethodMap,
-  ClientHandler (..),
-  MQTTRequest (..),
-SessionId) where
+module Network.GRPC.MQTT.Types
+  ( MQTTResult (..),
+    MethodMap,
+    ClientHandler (..),
+    MQTTRequest (..),
+    SessionId,
+  )
+where
 
 import Relude
 
 import qualified Network.GRPC.HighLevel as HL
-import Network.GRPC.HighLevel.Client (
-  ClientResult,
-  GRPCMethodType (Normal, ServerStreaming, ClientStreaming),
-  MetadataMap,
-  StreamRecv,
-  TimeoutSeconds, StreamSend
- )
+import Network.GRPC.HighLevel.Client
+  ( ClientResult,
+    GRPCMethodType (ClientStreaming, Normal, ServerStreaming),
+    MetadataMap,
+    StreamRecv,
+    StreamSend,
+    TimeoutSeconds,
+  )
 import Network.GRPC.LowLevel (ClientCall)
 import Proto3.Suite (Message)
 

--- a/src/Network/GRPC/MQTT/Wrapping.hs
+++ b/src/Network/GRPC/MQTT/Wrapping.hs
@@ -10,37 +10,37 @@ module Network.GRPC.MQTT.Wrapping where
 
 import Relude
 
-import Network.GRPC.MQTT.Types (
-  ClientHandler (ClientClientStreamHandler, ClientServerStreamHandler, ClientUnaryHandler),
-  MQTTResult (..),
- )
+import Network.GRPC.MQTT.Types
+  ( ClientHandler (ClientClientStreamHandler, ClientServerStreamHandler, ClientUnaryHandler),
+    MQTTResult (..),
+  )
 
-import Proto.Mqtt as Proto (
-  ClientStreamResponse (..),
-  List (List, listValue),
-  MetadataMap (MetadataMap),
-  Packet,
-  RCError (..),
-  RemoteClientError (..),
-  RemoteClientErrorExtra (..),
-  StreamResponse (..),
-  UnaryResponse (..),
-  WrappedClientStreamResponse (WrappedClientStreamResponse),
-  WrappedClientStreamResponseOrError (..),
-  WrappedMQTTRequest (WrappedMQTTRequest),
-  WrappedStreamChunk (WrappedStreamChunk),
-  WrappedStreamChunkOrError (
-    WrappedStreamChunkOrErrorError,
-    WrappedStreamChunkOrErrorValue
-  ),
-  WrappedStreamResponse (WrappedStreamResponse),
-  WrappedStreamResponseOrError (
-    WrappedStreamResponseOrErrorError,
-    WrappedStreamResponseOrErrorResponse
-  ),
-  WrappedUnaryResponse (..),
-  WrappedUnaryResponseOrErr (..),
- )
+import Proto.Mqtt as Proto
+  ( ClientStreamResponse (..),
+    List (List, listValue),
+    MetadataMap (MetadataMap),
+    Packet,
+    RCError (..),
+    RemoteClientError (..),
+    RemoteClientErrorExtra (..),
+    StreamResponse (..),
+    UnaryResponse (..),
+    WrappedClientStreamResponse (WrappedClientStreamResponse),
+    WrappedClientStreamResponseOrError (..),
+    WrappedMQTTRequest (WrappedMQTTRequest),
+    WrappedStreamChunk (WrappedStreamChunk),
+    WrappedStreamChunkOrError
+      ( WrappedStreamChunkOrErrorError,
+        WrappedStreamChunkOrErrorValue
+      ),
+    WrappedStreamResponse (WrappedStreamResponse),
+    WrappedStreamResponseOrError
+      ( WrappedStreamResponseOrErrorError,
+        WrappedStreamResponseOrErrorResponse
+      ),
+    WrappedUnaryResponse (..),
+    WrappedUnaryResponseOrErr (..),
+  )
 
 import Control.Exception (ErrorCall, try)
 import qualified Data.ByteString as BS
@@ -48,31 +48,31 @@ import Data.ByteString.Base64 (decodeBase64, encodeBase64)
 import qualified Data.Map as M
 import qualified Data.Vector as V
 import GHC.IO.Unsafe (unsafePerformIO)
-import Network.GRPC.HighLevel as HL (
-  GRPCIOError (..),
-  MetadataMap (MetadataMap),
-  StatusCode,
-  StatusDetails (..),
- )
-import Network.GRPC.HighLevel.Client (
-  ClientError (..),
-  ClientRequest (ClientNormalRequest, ClientReaderRequest, ClientWriterRequest),
-  ClientResult (
-    ClientErrorResponse,
-    ClientNormalResponse,
-    ClientReaderResponse,
-    ClientWriterResponse
-  ),
-  GRPCMethodType (ClientStreaming, Normal, ServerStreaming),
- )
+import Network.GRPC.HighLevel as HL
+  ( GRPCIOError (..),
+    MetadataMap (MetadataMap),
+    StatusCode,
+    StatusDetails (..),
+  )
+import Network.GRPC.HighLevel.Client
+  ( ClientError (..),
+    ClientRequest (ClientNormalRequest, ClientReaderRequest, ClientWriterRequest),
+    ClientResult
+      ( ClientErrorResponse,
+        ClientNormalResponse,
+        ClientReaderResponse,
+        ClientWriterResponse
+      ),
+    GRPCMethodType (ClientStreaming, Normal, ServerStreaming),
+  )
 import Network.GRPC.HighLevel.Server (toBS)
 import Network.GRPC.Unsafe (CallError (..))
-import Proto3.Suite (
-  Enumerated (Enumerated),
-  Message,
-  fromByteString,
-  toLazyByteString,
- )
+import Proto3.Suite
+  ( Enumerated (Enumerated),
+    Message,
+    fromByteString,
+    toLazyByteString,
+  )
 import Proto3.Wire.Decode (ParseError (..))
 
 -- Client Wrappers
@@ -136,29 +136,29 @@ wrapUnaryResponse res =
 
 unwrapUnaryResponse :: forall response. (Message response) => LByteString -> MQTTResult 'Normal response
 unwrapUnaryResponse wrappedMessage = either id id parsedResult
- where
-  parsedResult :: Either (MQTTResult 'Normal response) (MQTTResult 'Normal response)
-  parsedResult = do
-    WrappedUnaryResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
-    UnaryResponse{..} <- case mResponse of
-      Nothing -> Left $ MQTTError "Empty response"
-      Just (WrappedUnaryResponseOrErrError err) -> Left $ fromRemoteClientError err
-      Just (WrappedUnaryResponseOrErrResponse resp) -> Right resp
+  where
+    parsedResult :: Either (MQTTResult 'Normal response) (MQTTResult 'Normal response)
+    parsedResult = do
+      WrappedUnaryResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
+      UnaryResponse{..} <- case mResponse of
+        Nothing -> Left $ MQTTError "Empty response"
+        Just (WrappedUnaryResponseOrErrError err) -> Left $ fromRemoteClientError err
+        Just (WrappedUnaryResponseOrErrResponse resp) -> Right resp
 
-    parsedResponseBody <- parseWithClientError unaryResponseBody
+      parsedResponseBody <- parseWithClientError unaryResponseBody
 
-    statusCode <- case toStatusCode unaryResponseResponseCode of
-      Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show unaryResponseResponseCode)
-      Just sc -> Right sc
+      statusCode <- case toStatusCode unaryResponseResponseCode of
+        Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show unaryResponseResponseCode)
+        Just sc -> Right sc
 
-    return $
-      GRPCResult $
-        ClientNormalResponse
-          parsedResponseBody
-          (maybe mempty toMetadataMap unaryResponseInitMetamap)
-          (maybe mempty toMetadataMap unaryResponseTrailMetamap)
-          statusCode
-          (toStatusDetails unaryResponseDetails)
+      return $
+        GRPCResult $
+          ClientNormalResponse
+            parsedResponseBody
+            (maybe mempty toMetadataMap unaryResponseInitMetamap)
+            (maybe mempty toMetadataMap unaryResponseTrailMetamap)
+            statusCode
+            (toStatusDetails unaryResponseDetails)
 
 -- Client Streaming Wrappers
 wrapClientStreamResponse :: (Message response) => ClientResult 'ClientStreaming response -> LByteString
@@ -178,32 +178,32 @@ wrapClientStreamResponse res =
 
 unwrapClientStreamResponse :: forall response. (Message response) => LByteString -> MQTTResult 'ClientStreaming response
 unwrapClientStreamResponse wrappedMessage = either id id parsedResult
- where
-  parsedResult :: Either (MQTTResult 'ClientStreaming response) (MQTTResult 'ClientStreaming response)
-  parsedResult = do
-    WrappedClientStreamResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
-    ClientStreamResponse{..} <- case mResponse of
-      Nothing -> Left $ MQTTError "Empty response"
-      Just (WrappedClientStreamResponseOrErrorError err) -> Left $ fromRemoteClientError err
-      Just (WrappedClientStreamResponseOrErrorResponse resp) -> Right resp
+  where
+    parsedResult :: Either (MQTTResult 'ClientStreaming response) (MQTTResult 'ClientStreaming response)
+    parsedResult = do
+      WrappedClientStreamResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
+      ClientStreamResponse{..} <- case mResponse of
+        Nothing -> Left $ MQTTError "Empty response"
+        Just (WrappedClientStreamResponseOrErrorError err) -> Left $ fromRemoteClientError err
+        Just (WrappedClientStreamResponseOrErrorResponse resp) -> Right resp
 
-    statusCode <- case toStatusCode clientStreamResponseResponseCode of
-      Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show clientStreamResponseResponseCode)
-      Just sc -> Right sc
+      statusCode <- case toStatusCode clientStreamResponseResponseCode of
+        Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show clientStreamResponseResponseCode)
+        Just sc -> Right sc
 
-    response <-
-      if BS.null clientStreamResponseBody
-        then Right Nothing
-        else Just <$> parseWithClientError clientStreamResponseBody
+      response <-
+        if BS.null clientStreamResponseBody
+          then Right Nothing
+          else Just <$> parseWithClientError clientStreamResponseBody
 
-    return $
-      GRPCResult $
-        ClientWriterResponse
-          response
-          (maybe mempty toMetadataMap clientStreamResponseInitMetamap)
-          (maybe mempty toMetadataMap clientStreamResponseTrailMetamap)
-          statusCode
-          (toStatusDetails clientStreamResponseDetails)
+      return $
+        GRPCResult $
+          ClientWriterResponse
+            response
+            (maybe mempty toMetadataMap clientStreamResponseInitMetamap)
+            (maybe mempty toMetadataMap clientStreamResponseTrailMetamap)
+            statusCode
+            (toStatusDetails clientStreamResponseDetails)
 
 -- Streaming Wrappers
 wrapStreamInitMetadata :: HL.MetadataMap -> LByteString
@@ -225,25 +225,25 @@ wrapStreamResponse response =
 
 unwrapStreamResponse :: forall response. LByteString -> MQTTResult 'ServerStreaming response
 unwrapStreamResponse wrappedMessage = either id id parsedResult
- where
-  parsedResult :: Either (MQTTResult 'ServerStreaming response) (MQTTResult 'ServerStreaming response)
-  parsedResult = do
-    WrappedStreamResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
-    StreamResponse{..} <- case mResponse of
-      Nothing -> Left $ MQTTError "Empty response"
-      Just (WrappedStreamResponseOrErrorError err) -> Left $ fromRemoteClientError err
-      Just (WrappedStreamResponseOrErrorResponse resp) -> Right resp
+  where
+    parsedResult :: Either (MQTTResult 'ServerStreaming response) (MQTTResult 'ServerStreaming response)
+    parsedResult = do
+      WrappedStreamResponse mResponse <- parseWithClientError (toStrict wrappedMessage)
+      StreamResponse{..} <- case mResponse of
+        Nothing -> Left $ MQTTError "Empty response"
+        Just (WrappedStreamResponseOrErrorError err) -> Left $ fromRemoteClientError err
+        Just (WrappedStreamResponseOrErrorResponse resp) -> Right resp
 
-    statusCode <- case toStatusCode streamResponseResponseCode of
-      Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show streamResponseResponseCode)
-      Just sc -> Right sc
+      statusCode <- case toStatusCode streamResponseResponseCode of
+        Nothing -> Left $ MQTTError ("Invalid reponse code: " <> show streamResponseResponseCode)
+        Just sc -> Right sc
 
-    return $
-      GRPCResult $
-        ClientReaderResponse
-          (maybe mempty toMetadataMap streamResponseMetamap)
-          statusCode
-          (toStatusDetails streamResponseDetails)
+      return $
+        GRPCResult $
+          ClientReaderResponse
+            (maybe mempty toMetadataMap streamResponseMetamap)
+            statusCode
+            (toStatusDetails streamResponseDetails)
 
 wrapStreamChunk :: (Message response) => Maybe response -> LByteString
 wrapStreamChunk chunk =
@@ -251,10 +251,9 @@ wrapStreamChunk chunk =
     WrappedStreamChunk
       (WrappedStreamChunkOrErrorValue . toBS <$> chunk)
 
-unwrapStreamChunk :: (Message response) => Either RemoteClientError ByteString -> Either GRPCIOError (Maybe response)
-unwrapStreamChunk (Left err) = Left $ toGRPCIOError err
-unwrapStreamChunk (Right msg) =
-  case fromByteString msg of
+unwrapStreamChunk :: (Message response) => LByteString -> Either GRPCIOError (Maybe response)
+unwrapStreamChunk msg =
+  case fromByteString (toStrict msg) of
     Left err -> Left $ GRPCIODecodeError (displayException err)
     Right (WrappedStreamChunk chunk) ->
       case chunk of
@@ -276,42 +275,54 @@ unwrapPacket bs =
 
 -- Utility functions
 wrapMQTTError :: LText -> LByteString
-wrapMQTTError errMsg =
-  toLazyByteString $
-    RemoteClientError
-      { remoteClientErrorErrorType = Enumerated $ Right RCErrorMQTTFailure
-      , remoteClientErrorMessage = errMsg
-      , remoteClientErrorExtra = Nothing
-      }
+wrapMQTTError = toLazyByteString . rceMQTTError
+
+rceMQTTError :: LText -> RemoteClientError
+rceMQTTError errMsg = 
+  RemoteClientError
+    { remoteClientErrorErrorType = Enumerated $ Right RCErrorMQTTFailure
+    , remoteClientErrorMessage = errMsg
+    , remoteClientErrorExtra = Nothing
+    }
 
 parseWithClientError :: (Message a) => ByteString -> Either (MQTTResult streamtype response) a
 parseWithClientError = first (GRPCResult . ClientErrorResponse . ClientErrorNoParse) . fromByteString
+
+unwrapMetadataMap :: LByteString -> Either RemoteClientError HL.MetadataMap
+unwrapMetadataMap msg =
+  case fromByteString (toStrict msg) of
+    Right x -> Right (toMetadataMap x)
+    Left parseErr ->
+      case fromByteString @RemoteClientError (toStrict msg) of
+        Left _ -> Left (parseErrorToRCE parseErr)
+        Right recvErr -> Left recvErr
+
 
 -- Protobuf type conversions
 
 -- | NB: Destroys keys that fail to decode
 toMetadataMap :: Proto.MetadataMap -> HL.MetadataMap
 toMetadataMap (Proto.MetadataMap m) = HL.MetadataMap (convertVals <$> M.mapKeys convertKeys m)
- where
-  convertVals = maybe [] (V.toList . listValue)
-  convertKeys k =
-    case decodeBase64 $ encodeUtf8 k of
-      Left _err -> mempty
-      Right k' -> k'
+  where
+    convertVals = maybe [] (V.toList . listValue)
+    convertKeys k =
+      case decodeBase64 $ encodeUtf8 k of
+        Left _err -> mempty
+        Right k' -> k'
 
 fromMetadataMap :: HL.MetadataMap -> Proto.MetadataMap
 fromMetadataMap (HL.MetadataMap m) = Proto.MetadataMap (convertVals <$> M.mapKeys convertKeys m)
- where
-  convertVals = Just . List . V.fromList
-  convertKeys = fromStrict . encodeBase64
+  where
+    convertVals = Just . List . V.fromList
+    convertKeys = fromStrict . encodeBase64
 
 toStatusCode :: Int32 -> Maybe StatusCode
 toStatusCode = toEnumMaybe . fromIntegral
- where
-  toEnumMaybe x =
-    case unsafePerformIO $ try @ErrorCall (evaluateWHNF (toEnum x)) of
-      Left _ -> Nothing
-      Right sc -> Just sc
+  where
+    toEnumMaybe x =
+      case unsafePerformIO $ try @ErrorCall (evaluateWHNF (toEnum x)) of
+        Left _ -> Nothing
+        Right sc -> Just sc
 
 fromStatusCode :: StatusCode -> Int32
 fromStatusCode = fromIntegral . fromEnum
@@ -353,9 +364,9 @@ toRemoteClientError (ClientIOError ge) =
     GRPCIODecodeError s -> wrapRCE RCErrorIOGRPCDecode (fromString s) Nothing
     GRPCIOInternalUnexpectedRecv s -> wrapRCE RCErrorIOGRPCInternalUnexpectedRecv (fromString s) Nothing
     GRPCIOHandlerException s -> wrapRCE RCErrorIOGRPCHandlerException (fromString s) Nothing
- where
-  wrapRCE errType = RemoteClientError (Enumerated (Right errType))
-  wrapPlainRCE errType = wrapRCE errType "" Nothing
+  where
+    wrapRCE errType = RemoteClientError (Enumerated (Right errType))
+    wrapPlainRCE errType = wrapRCE errType "" Nothing
 
 fromRemoteClientError :: RemoteClientError -> MQTTResult streamtype response
 fromRemoteClientError (RemoteClientError (Enumerated errType) errMsg errExtra) =
@@ -393,9 +404,9 @@ fromRemoteClientError (RemoteClientError (Enumerated errType) errMsg errExtra) =
     Right RCErrorUnknownError -> MQTTError $ "Unknown error: " <> toStrict errMsg
     Right RCErrorMQTTFailure -> MQTTError $ toStrict errMsg
     Left _ -> MQTTError $ "Unknown error: " <> toStrict errMsg
- where
-  wrapGRPCResult = GRPCResult . ClientErrorResponse . ClientIOError
-  wrapNoParseResult = GRPCResult . ClientErrorResponse . ClientErrorNoParse
+  where
+    wrapGRPCResult = GRPCResult . ClientErrorResponse . ClientIOError
+    wrapNoParseResult = GRPCResult . ClientErrorResponse . ClientErrorNoParse
 
 handleEmbedded :: RemoteClientErrorExtra -> Maybe ParseError
 handleEmbedded (RemoteClientErrorExtraEmbeddedError (RemoteClientError (Enumerated (Right errType)) errMsg errExtra)) =

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -9,94 +9,96 @@ module Main where
 
 import Relude
 
-import Test.GRPCServers (
-  addHelloHandlers,
-  addHelloService,
-  infiniteHelloSSHandler,
-  multGoodbyeService,
- )
-import Test.Helpers (
-  assertContains,
-  getTestConfig,
-  notParallel,
-  streamTester,
-  testLogger,
-  timeit,
- )
-import Test.ProtoClients (
-  addHelloMqttClient,
-  multGoodbyeMqttClient,
- )
-import Test.ProtoRemoteClients (
-  addHelloRemoteClientMethodMap,
-  multGoodbyeRemoteClientMethodMap,
- )
+import Test.GRPCServers
+  ( addHelloHandlers,
+    addHelloService,
+    infiniteHelloSSHandler,
+    multGoodbyeService,
+  )
+import Test.Helpers
+  ( assertContains,
+    getTestConfig,
+    notParallel,
+    streamTester,
+    testLogger,
+    timeit,
+  )
+import Test.ProtoClients
+  ( addHelloMqttClient,
+    multGoodbyeMqttClient,
+  )
+import Test.ProtoRemoteClients
+  ( addHelloRemoteClientMethodMap,
+    multGoodbyeRemoteClientMethodMap,
+  )
 
-import Network.GRPC.MQTT (
-  MessageCallback (SimpleCallback),
-  QoS (QoS1),
-  SubOptions (_subQoS),
-  Topic,
-  normalDisconnect,
-  publishq,
-  subOptions,
-  subscribe,
- )
-import Network.GRPC.MQTT.Client (
-  MQTTGRPCClient (mqttClient),
-  withMQTTGRPCClient,
- )
-import Network.GRPC.MQTT.Core (
-  MQTTGRPCConfig (mqttMsgSizeLimit, _connID, _msgCB),
-  connectMQTT,
-  toFilter,
- )
+import Network.GRPC.MQTT
+  ( Topic,
+  )
+import Network.GRPC.MQTT.Client
+  ( MQTTGRPCClient (mqttClient),
+    withMQTTGRPCClient,
+  )
+import Network.GRPC.MQTT.Core
+  ( MQTTGRPCConfig (mqttMsgSizeLimit, _connID, _msgCB),
+    connectMQTT,
+  )
 import Network.GRPC.MQTT.RemoteClient (runRemoteClient)
-import Network.GRPC.MQTT.Sequenced (
-  SequenceIdx (SequencedIdx),
-  Sequenced (..),
-  mkSequencedRead,
- )
-import Network.GRPC.MQTT.Types (
-  MQTTRequest (MQTTNormalRequest, MQTTReaderRequest, MQTTWriterRequest),
-  MQTTResult (GRPCResult, MQTTError),
- )
+import Network.GRPC.MQTT.Sequenced
+  ( SequenceIdx (SequencedIdx),
+    Sequenced (..),
+    mkSequencedRead,
+  )
+import Network.GRPC.MQTT.Types
+  ( MQTTRequest (MQTTNormalRequest, MQTTReaderRequest, MQTTWriterRequest),
+    MQTTResult (GRPCResult, MQTTError),
+  )
 
-import Data.Time.Clock (
-  diffUTCTime,
-  getCurrentTime,
-  nominalDiffTimeToSeconds,
- )
-import Network.GRPC.HighLevel.Client (
-  ClientConfig (..),
-  ClientError (ClientIOError),
-  ClientResult (..),
-  Port,
-  StatusCode (StatusOk),
-  StreamSend,
- )
-import Network.GRPC.HighLevel.Generated (
-  GRPCIOError (GRPCIOTimeout),
-  ServiceOptions (serverPort),
-  defaultServiceOptions,
-  withGRPCClient,
- )
-import Proto.Test (
-  AddHello (AddHello, addHelloHelloSS),
-  MultGoodbye (MultGoodbye),
-  OneInt (OneInt),
-  SSRpy (ssrpyGreeting),
-  SSRqt (SSRqt),
-  TwoInts (TwoInts),
-  addHelloServer,
- )
+import Data.Time.Clock
+  ( diffUTCTime,
+    getCurrentTime,
+    nominalDiffTimeToSeconds,
+  )
+import Network.GRPC.HighLevel.Client
+  ( ClientConfig (..),
+    ClientError (ClientIOError),
+    ClientResult (..),
+    Port,
+    StatusCode (StatusOk),
+    StreamSend,
+  )
+import Network.GRPC.HighLevel.Generated
+  ( GRPCIOError (GRPCIOTimeout),
+    ServiceOptions (serverPort),
+    defaultServiceOptions,
+    withGRPCClient,
+  )
+import Network.MQTT.Client
+  ( MessageCallback (SimpleCallback),
+    QoS (QoS1),
+    SubOptions (_subQoS),
+    normalDisconnect,
+    publishq,
+    subOptions,
+    subscribe,
+  )
+import Network.MQTT.Topic (toFilter)
+import Proto.Test
+  ( AddHello (AddHello, addHelloHelloSS),
+    MultGoodbye (MultGoodbye),
+    OneInt (OneInt),
+    SSRpy (ssrpyGreeting),
+    SSRqt (SSRqt),
+    TwoInts (TwoInts),
+    addHelloServer,
+  )
 import Test.Tasty (TestTree, defaultMain, testGroup)
-import Test.Tasty.HUnit (
-  Assertion,
-  assertBool,
-  assertFailure,
-  (@?=),
- )
+import Test.Tasty.HUnit
+  ( Assertion,
+    assertBool,
+    assertFailure,
+    (@?=),
+  )
 import Turtle (sleep)
 import UnliftIO.Async (concurrently_, withAsync)
 import UnliftIO.STM (newTChanIO, readTChan, writeTChan)

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -47,7 +47,7 @@ import Network.GRPC.MQTT.Client (
   withMQTTGRPCClient,
  )
 import Network.GRPC.MQTT.Core (
-  MQTTGRPCConfig (_connID, _msgCB, mqttMsgSizeLimit),
+  MQTTGRPCConfig (mqttMsgSizeLimit, _connID, _msgCB),
   connectMQTT,
   toFilter,
  )
@@ -72,7 +72,8 @@ import Network.GRPC.HighLevel.Client (
   ClientError (ClientIOError),
   ClientResult (..),
   Port,
-  StatusCode (StatusOk), StreamSend
+  StatusCode (StatusOk),
+  StreamSend,
  )
 import Network.GRPC.HighLevel.Generated (
   GRPCIOError (GRPCIOTimeout),
@@ -141,18 +142,17 @@ allTests :: TestTree
 allTests =
   testGroup "All Tests" $
     notParallel
-      [
-      --   ("Latency", mqttLatency)
-      -- , ("Basic Unary", basicUnary)
-      -- , ("Basic Server Streaming", basicServerStreaming)
-      ("Basic Client Streaming", basicClientStreaming)
-      -- , ("Two Servers", twoServers)
-      -- , ("Timeout", testTimeout)
-      -- , ("Persistent", persistentMQTT)
-      -- , ("Sequenced", testSequenced)
-      -- , ("Missing Client Error", missingClientError)
-      -- , ("Malformed Topic", malformedMessage)
-      -- , ("Packetized", packetizedMesssages)
+      [ ("Latency", mqttLatency)
+      , ("Basic Unary", basicUnary)
+      , ("Basic Server Streaming", basicServerStreaming)
+      , ("Basic Client Streaming", basicClientStreaming)
+      , ("Two Servers", twoServers)
+      , ("Timeout", testTimeout)
+      , ("Persistent", persistentMQTT)
+      , ("Sequenced", testSequenced)
+      , ("Missing Client Error", missingClientError)
+      , ("Malformed Topic", malformedMessage)
+      , ("Packetized", packetizedMesssages)
       ]
 
 persistentMQTT :: Assertion
@@ -285,7 +285,6 @@ basicClientStreaming = do
         sleep 1
         testSumCall awsConfig{_connID = testClientId <> "CS"}
 
-
 packetizedMesssages :: Assertion
 packetizedMesssages = do
   awsConfig <- getTestConfig
@@ -384,10 +383,7 @@ testSumCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
 clientStreamTester :: StreamSend OneInt -> IO ()
 clientStreamTester send = do
   eithers <- forM @[] [OneInt 1, OneInt 2, OneInt 3] $ \int -> do
-    putStrLn $ "clientStreamTester: " <> show int
-    x <- send int
-    print x
-    pure x
+    send int
   case sequence eithers of
     Left err -> assertFailure $ "Error while client streaming: " ++ show err
     Right _ -> pure ()

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -58,7 +58,7 @@ import Network.GRPC.MQTT.Sequenced (
   mkSequencedRead,
  )
 import Network.GRPC.MQTT.Types (
-  MQTTRequest (MQTTNormalRequest, MQTTReaderRequest),
+  MQTTRequest (MQTTNormalRequest, MQTTReaderRequest, MQTTWriterRequest),
   MQTTResult (GRPCResult, MQTTError),
  )
 
@@ -72,7 +72,7 @@ import Network.GRPC.HighLevel.Client (
   ClientError (ClientIOError),
   ClientResult (..),
   Port,
-  StatusCode (StatusOk),
+  StatusCode (StatusOk), StreamSend
  )
 import Network.GRPC.HighLevel.Generated (
   GRPCIOError (GRPCIOTimeout),
@@ -141,16 +141,18 @@ allTests :: TestTree
 allTests =
   testGroup "All Tests" $
     notParallel
-      [ ("Latency", mqttLatency)
-      , ("Basic Unary", basicUnary)
-      , ("Basic Server Streaming", basicServerStreaming)
-      , ("Two Servers", twoServers)
-      , ("Timeout", testTimeout)
-      , ("Persistent", persistentMQTT)
-      , ("Sequenced", testSequenced)
-      , ("Missing Client Error", missingClientError)
-      , ("Malformed Topic", malformedMessage)
-      , ("Packetized", packetizedMesssages)
+      [
+      --   ("Latency", mqttLatency)
+      -- , ("Basic Unary", basicUnary)
+      -- , ("Basic Server Streaming", basicServerStreaming)
+      ("Basic Client Streaming", basicClientStreaming)
+      -- , ("Two Servers", twoServers)
+      -- , ("Timeout", testTimeout)
+      -- , ("Persistent", persistentMQTT)
+      -- , ("Sequenced", testSequenced)
+      -- , ("Missing Client Error", missingClientError)
+      -- , ("Malformed Topic", malformedMessage)
+      -- , ("Packetized", packetizedMesssages)
       ]
 
 persistentMQTT :: Assertion
@@ -166,7 +168,7 @@ persistentMQTT = do
       withAsync (runRemoteClient testLogger awsConfig{_connID = "testMachineSSAdaptor"} testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
         withMQTTGRPCClient testLogger awsConfig{_connID = testClientId} $ \client -> do
-          let AddHello mqttAdd mqttHelloSS = addHelloMqttClient client testBaseTopic
+          let AddHello mqttAdd mqttHelloSS _ = addHelloMqttClient client testBaseTopic
 
           mqttAdd (MQTTNormalRequest (TwoInts 4 6) 2 []) >>= \case
             GRPCResult (ClientNormalResponse result _ _ _ _) -> result @?= OneInt 10
@@ -203,7 +205,7 @@ streamingTermination = do
       withAsync (runRemoteClient testLogger awsConfig{_connID = "testMachineSSAdaptor"} testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
         withMQTTGRPCClient testLogger awsConfig{_connID = testClientId} $ \client -> do
-          let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
+          let AddHello _ mqttHelloSS _ = addHelloMqttClient client testBaseTopic
           let testInput = SSRqt "Alice" 1
               request = MQTTReaderRequest testInput 20 [] (streamTester (assertContains "Alice" . ssrpyGreeting))
 
@@ -216,7 +218,7 @@ testTimeout = do
   awsConfig <- getTestConfig
 
   withMQTTGRPCClient testLogger awsConfig{_connID = testClientId} $ \client -> do
-    let AddHello mqttAdd mqttHelloSS = addHelloMqttClient client testBaseTopic
+    let AddHello mqttAdd mqttHelloSS _ = addHelloMqttClient client testBaseTopic
 
     addResponse <- timeit 3 $ mqttAdd (MQTTNormalRequest (TwoInts 9 16) 2 [])
     case addResponse of
@@ -243,7 +245,7 @@ basicUnary = do
         --Delay to allow remote client to start receiving MQTT messages
         sleep 1
         withMQTTGRPCClient testLogger awsConfig{_connID = testClientId <> "BU"} $ \client -> do
-          let AddHello mqttAdd _ = addHelloMqttClient client testBaseTopic
+          let AddHello mqttAdd _ _ = addHelloMqttClient client testBaseTopic
           let testInput = TwoInts 4 6
               expectedResult = OneInt 10
               request = MQTTNormalRequest testInput 5 []
@@ -267,6 +269,22 @@ basicServerStreaming = do
       withAsync (runRemoteClient testLogger awsConfig{_connID = "testMachineSSAdaptorSS"} testBaseTopic methodMap) $ \_adaptorThread -> do
         sleep 1
         testHelloCall awsConfig{_connID = testClientId <> "SS"}
+
+basicClientStreaming :: Assertion
+basicClientStreaming = do
+  awsConfig <- getTestConfig
+
+  -- Start gRPC Server
+  withAsync runAddHelloServer $ \_grpcServerThread ->
+    -- Get gRPC Client
+    withGRPCClient (testGrpcClientConfig addHelloServerPort) $ \grpcClient -> do
+      methodMap <- addHelloRemoteClientMethodMap grpcClient
+
+      -- Start serverside MQTT adaptor
+      withAsync (runRemoteClient testLogger awsConfig{_connID = "testMachineAdaptorCS"} testBaseTopic methodMap) $ \_adaptorThread -> do
+        sleep 1
+        testSumCall awsConfig{_connID = testClientId <> "CS"}
+
 
 packetizedMesssages :: Assertion
 packetizedMesssages = do
@@ -296,7 +314,7 @@ missingClientError = do
       withAsync (runRemoteClient testLogger awsConfig{_connID = "testMachineSSAdaptorSS"} testBaseTopic []) $ \_adaptorThread -> do
         sleep 1
         withMQTTGRPCClient testLogger awsConfig{_connID = testClientId <> "SS"} $ \client -> do
-          let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
+          let AddHello _ mqttHelloSS _ = addHelloMqttClient client testBaseTopic
               testInput = SSRqt "Alice" 2
               request = MQTTReaderRequest testInput 5 [("alittlebit", "ofinitialmetadata")] (streamTester (assertContains "Alice" . ssrpyGreeting))
 
@@ -332,7 +350,7 @@ twoServers = do
 
 testAddCall :: MQTTGRPCConfig -> Assertion
 testAddCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
-  let AddHello mqttAdd _ = addHelloMqttClient client testBaseTopic
+  let AddHello mqttAdd _ _ = addHelloMqttClient client testBaseTopic
   let testInput = TwoInts 4 6
       expectedResult = OneInt 10
       request = MQTTNormalRequest testInput 5 []
@@ -344,7 +362,7 @@ testAddCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
 
 testHelloCall :: MQTTGRPCConfig -> Assertion
 testHelloCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
-  let AddHello _ mqttHelloSS = addHelloMqttClient client testBaseTopic
+  let AddHello _ mqttHelloSS _ = addHelloMqttClient client testBaseTopic
       testInput = SSRqt "Alice" 2
       request = MQTTReaderRequest testInput 5 [("alittlebit", "ofinitialmetadata")] (streamTester (assertContains "Alice" . ssrpyGreeting))
 
@@ -353,9 +371,30 @@ testHelloCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
     GRPCResult (ClientErrorResponse err) -> assertFailure $ "helloSS Client error: " <> show err
     MQTTError err -> assertFailure $ "helloSS mqtt error: " <> show err
 
+testSumCall :: MQTTGRPCConfig -> Assertion
+testSumCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
+  let AddHello _ _ mqttSumCS = addHelloMqttClient client testBaseTopic
+      request = MQTTWriterRequest 5 [("alittlebit", "ofinitialmetadata")] clientStreamTester
+
+  mqttSumCS request >>= \case
+    GRPCResult (ClientWriterResponse mres _ _ _status _) -> mres @?= Just (OneInt 6) --status @?= StatusOk
+    GRPCResult (ClientErrorResponse err) -> assertFailure $ "sumCS Client error: " <> show err
+    MQTTError err -> assertFailure $ "sumCS mqtt error: " <> show err
+
+clientStreamTester :: StreamSend OneInt -> IO ()
+clientStreamTester send = do
+  eithers <- forM @[] [OneInt 1, OneInt 2, OneInt 3] $ \int -> do
+    putStrLn $ "clientStreamTester: " <> show int
+    x <- send int
+    print x
+    pure x
+  case sequence eithers of
+    Left err -> assertFailure $ "Error while client streaming: " ++ show err
+    Right _ -> pure ()
+
 testMultCall :: MQTTGRPCConfig -> Assertion
 testMultCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
-  let MultGoodbye mqttMult _ = multGoodbyeMqttClient client testBaseTopic
+  let MultGoodbye mqttMult _ _ = multGoodbyeMqttClient client testBaseTopic
       testInput = TwoInts 4 6
       expectedResult = OneInt 24
       request = MQTTNormalRequest testInput 5 []
@@ -367,7 +406,7 @@ testMultCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
 
 testGoodbyeCall :: MQTTGRPCConfig -> Assertion
 testGoodbyeCall cfg = withMQTTGRPCClient testLogger cfg $ \client -> do
-  let MultGoodbye _ mqttGoodbyeSS = multGoodbyeMqttClient client testBaseTopic
+  let MultGoodbye _ mqttGoodbyeSS _ = multGoodbyeMqttClient client testBaseTopic
       testInput = SSRqt "Alice" 3
       request = MQTTReaderRequest testInput 10 [] (streamTester (assertContains "Alice" . ssrpyGreeting))
 
@@ -420,7 +459,7 @@ malformedMessage = do
           sleep 1
 
           -- Test server is still up and responsive
-          let AddHello mqttAdd _ = addHelloMqttClient client testBaseTopic
+          let AddHello mqttAdd _ _ = addHelloMqttClient client testBaseTopic
           let testInput = TwoInts 4 6
               expectedResult = OneInt 10
               request = MQTTNormalRequest testInput 5 []

--- a/test/Test/GRPCServers.hs
+++ b/test/Test/GRPCServers.hs
@@ -89,7 +89,6 @@ runningSumHandler (ServerReaderRequest _metadata recv) = loop 0
  where
   loop !i = do
     msg <- recv
-    putStrLn $ "runningSumHandler: " <> show msg
     case msg of
       Left err ->
         return
@@ -101,7 +100,6 @@ runningSumHandler (ServerReaderRequest _metadata recv) = loop 0
           )
       Right (Just (OneInt x)) -> loop (i + x)
       Right Nothing -> do
-        putStrLn "runningSumHandler returning response"
         return
           ( ServerReaderResponse
               (Just (OneInt i))

--- a/test/Test/GRPCServers.hs
+++ b/test/Test/GRPCServers.hs
@@ -9,27 +9,27 @@ module Test.GRPCServers where
 
 import Relude
 
-import Proto.Test (
-  AddHello (..),
-  MultGoodbye (..),
-  OneInt (OneInt),
-  SSRpy (SSRpy),
-  SSRqt (SSRqt),
-  TwoInts (TwoInts),
-  addHelloServer,
-  multGoodbyeServer,
- )
+import Proto.Test
+  ( AddHello (..),
+    MultGoodbye (..),
+    OneInt (OneInt),
+    SSRpy (SSRpy),
+    SSRqt (SSRqt),
+    TwoInts (TwoInts),
+    addHelloServer,
+    multGoodbyeServer,
+  )
 
-import Network.GRPC.HighLevel (
-  ServiceOptions,
-  StatusCode (StatusOk),
- )
-import Network.GRPC.HighLevel.Generated (
-  GRPCMethodType (ClientStreaming, Normal, ServerStreaming),
-  ServerRequest (ServerNormalRequest, ServerReaderRequest, ServerWriterRequest),
-  ServerResponse (ServerNormalResponse, ServerReaderResponse, ServerWriterResponse),
-  StatusCode (StatusUnknown),
- )
+import Network.GRPC.HighLevel
+  ( ServiceOptions,
+    StatusCode (StatusOk),
+  )
+import Network.GRPC.HighLevel.Generated
+  ( GRPCMethodType (ClientStreaming, Normal, ServerStreaming),
+    ServerRequest (ServerNormalRequest, ServerReaderRequest, ServerWriterRequest),
+    ServerResponse (ServerNormalResponse, ServerReaderResponse, ServerWriterResponse),
+    StatusCode (StatusUnknown),
+  )
 import Turtle (sleep)
 
 addHelloService :: ServiceOptions -> IO ()
@@ -66,9 +66,9 @@ helloSSHandler (ServerWriterRequest _metadata (SSRqt name numReplies) ssend) = d
     sleep 0.1
 
   return $ ServerWriterResponse [("metadata_field", "metadata_helloSS")] StatusOk "Stream is done"
- where
-  greeting :: Int -> SSRpy
-  greeting i = SSRpy $ "Hello, " <> name <> " - " <> show i
+  where
+    greeting :: Int -> SSRpy
+    greeting i = SSRpy $ "Hello, " <> name <> " - " <> show i
 
 infiniteHelloSSHandler :: ServerRequest 'ServerStreaming SSRqt SSRpy -> IO (ServerResponse 'ServerStreaming SSRpy)
 infiniteHelloSSHandler (ServerWriterRequest _metadata (SSRqt name _) ssend) = do
@@ -80,33 +80,33 @@ infiniteHelloSSHandler (ServerWriterRequest _metadata (SSRqt name _) ssend) = do
     sleep 0.1
 
   return $ ServerWriterResponse [("metadata_field", "metadata_infiniteHelloSS")] StatusOk "Stream is done"
- where
-  greeting :: Int -> SSRpy
-  greeting i = SSRpy $ "Hello, " <> name <> " - " <> show i
+  where
+    greeting :: Int -> SSRpy
+    greeting i = SSRpy $ "Hello, " <> name <> " - " <> show i
 
 runningSumHandler :: ServerRequest 'ClientStreaming OneInt OneInt -> IO (ServerResponse 'ClientStreaming OneInt)
 runningSumHandler (ServerReaderRequest _metadata recv) = loop 0
- where
-  loop !i = do
-    msg <- recv
-    case msg of
-      Left err ->
-        return
-          ( ServerReaderResponse
-              Nothing
-              []
-              StatusUnknown
-              (fromString (show err))
-          )
-      Right (Just (OneInt x)) -> loop (i + x)
-      Right Nothing -> do
-        return
-          ( ServerReaderResponse
-              (Just (OneInt i))
-              []
-              StatusOk
-              ""
-          )
+  where
+    loop !i = do
+      msg <- recv
+      case msg of
+        Left err ->
+          return
+            ( ServerReaderResponse
+                Nothing
+                []
+                StatusUnknown
+                (fromString (show err))
+            )
+        Right (Just (OneInt x)) -> loop (i + x)
+        Right Nothing -> do
+          return
+            ( ServerReaderResponse
+                (Just (OneInt i))
+                []
+                StatusOk
+                ""
+            )
 
 multGoodbyeService :: ServiceOptions -> IO ()
 multGoodbyeService = multGoodbyeServer multGoodbyeHandlers
@@ -140,29 +140,29 @@ goodbyeSSHandler (ServerWriterRequest _metadata (SSRqt name numReplies) ssend) =
     sleep 0.1
 
   return $ ServerWriterResponse [("metadata_field", "metadata_value")] StatusOk "Stream is done"
- where
-  sendoff i = SSRpy $ "Good Bye, " <> name <> " - " <> show i
+  where
+    sendoff i = SSRpy $ "Good Bye, " <> name <> " - " <> show i
 
 runningProdHandler :: ServerRequest 'ClientStreaming OneInt OneInt -> IO (ServerResponse 'ClientStreaming OneInt)
 runningProdHandler (ServerReaderRequest _metadata recv) = loop 0
- where
-  loop !i = do
-    msg <- recv
-    case msg of
-      Left err ->
-        return
-          ( ServerReaderResponse
-              Nothing
-              []
-              StatusUnknown
-              (fromString (show err))
-          )
-      Right (Just (OneInt x)) -> loop (i * x)
-      Right Nothing ->
-        return
-          ( ServerReaderResponse
-              (Just (OneInt i))
-              []
-              StatusOk
-              ""
-          )
+  where
+    loop !i = do
+      msg <- recv
+      case msg of
+        Left err ->
+          return
+            ( ServerReaderResponse
+                Nothing
+                []
+                StatusUnknown
+                (fromString (show err))
+            )
+        Right (Just (OneInt x)) -> loop (i * x)
+        Right Nothing ->
+          return
+            ( ServerReaderResponse
+                (Just (OneInt i))
+                []
+                StatusOk
+                ""
+            )

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -8,44 +8,44 @@ module Test.Helpers where
 
 import Relude
 
-import Network.GRPC.MQTT (
-  ProtocolLevel (Protocol311),
- )
+import Network.GRPC.MQTT
+  ( ProtocolLevel (Protocol311),
+  )
 import Network.GRPC.MQTT.Core (MQTTGRPCConfig (..), defaultMGConfig)
 import Network.GRPC.MQTT.Logging (Logger (..), noLogging)
 
 import Data.Default (Default (def))
 import qualified Data.Text.Lazy as TL
-import Data.X509.CertificateStore (
-  CertificateStore,
-  readCertificateStore,
- )
+import Data.X509.CertificateStore
+  ( CertificateStore,
+    readCertificateStore,
+  )
 import Network.Connection (TLSSettings (TLSSettings))
 import Network.GRPC.HighLevel.Client (MetadataMap, StreamRecv)
-import Network.TLS (
-  ClientHooks (onCertificateRequest),
-  ClientParams (clientHooks, clientShared, clientSupported),
-  Credential,
-  Credentials (Credentials),
-  HostName,
-  Shared (sharedCAStore, sharedCredentials),
-  Supported (supportedCiphers),
-  credentialLoadX509,
-  defaultParamsClient,
- )
+import Network.TLS
+  ( ClientHooks (onCertificateRequest),
+    ClientParams (clientHooks, clientShared, clientSupported),
+    Credential,
+    Credentials (Credentials),
+    HostName,
+    Shared (sharedCAStore, sharedCredentials),
+    Supported (supportedCiphers),
+    credentialLoadX509,
+    defaultParamsClient,
+  )
 import Network.TLS.Extra.Cipher (ciphersuite_default)
-import Test.Tasty (
-  DependencyType (AllFinish),
-  TestName,
-  TestTree,
-  after,
- )
-import Test.Tasty.HUnit (
-  Assertion,
-  assertBool,
-  assertFailure,
-  testCase,
- )
+import Test.Tasty
+  ( DependencyType (AllFinish),
+    TestName,
+    TestTree,
+    after,
+  )
+import Test.Tasty.HUnit
+  ( Assertion,
+    assertBool,
+    assertFailure,
+    testCase,
+  )
 import Test.Tasty.Runners (timed)
 import Turtle.Prelude (need)
 
@@ -115,16 +115,16 @@ timeit limit action = do
 
 streamTester :: (response -> Assertion) -> MetadataMap -> StreamRecv response -> IO ()
 streamTester assertProp _mm sr = loop
- where
-  loop =
-    sr >>= \case
-      Left err -> assertFailure (show err)
-      Right Nothing -> pure ()
-      Right (Just rsp) -> assertProp rsp >> loop
+  where
+    loop =
+      sr >>= \case
+        Left err -> assertFailure (show err)
+        Right Nothing -> pure ()
+        Right (Just rsp) -> assertProp rsp >> loop
 
 notParallel :: [(TestName, Assertion)] -> [TestTree]
 notParallel = foldr f []
- where
-  f :: (TestName, Assertion) -> [TestTree] -> [TestTree]
-  f (name, t) [] = [testCase name t]
-  f (name, t) (lt : rest) = testCase name t : after AllFinish name lt : rest
+  where
+    f :: (TestName, Assertion) -> [TestTree] -> [TestTree]
+    f (name, t) [] = [testCase name t]
+    f (name, t) (lt : rest) = testCase name t : after AllFinish name lt : rest

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -12,7 +12,7 @@ import Network.GRPC.MQTT (
   ProtocolLevel (Protocol311),
  )
 import Network.GRPC.MQTT.Core (MQTTGRPCConfig (..), defaultMGConfig)
-import Network.GRPC.MQTT.Logging (Logger (..), Verbosity (Debug))
+import Network.GRPC.MQTT.Logging (Logger (..), noLogging)
 
 import Data.Default (Default (def))
 import qualified Data.Text.Lazy as TL
@@ -50,14 +50,13 @@ import Test.Tasty.Runners (timed)
 import Turtle.Prelude (need)
 
 testLogger :: Logger
-testLogger = Logger print Debug
+testLogger = noLogging
 
 awsMqttConfig :: HostName -> Credential -> CertificateStore -> MQTTGRPCConfig
 awsMqttConfig hostName cred certStore =
   defaultMGConfig
     { useTLS = True
     , mqttMsgSizeLimit = 128000
-    
     , _protocol = Protocol311
     , _hostname = hostName
     , _port = 8883

--- a/test/Test/Helpers.hs
+++ b/test/Test/Helpers.hs
@@ -12,7 +12,7 @@ import Network.GRPC.MQTT (
   ProtocolLevel (Protocol311),
  )
 import Network.GRPC.MQTT.Core (MQTTGRPCConfig (..), defaultMGConfig)
-import Network.GRPC.MQTT.Logging (Logger (..), noLogging)
+import Network.GRPC.MQTT.Logging (Logger (..), Verbosity (Debug))
 
 import Data.Default (Default (def))
 import qualified Data.Text.Lazy as TL
@@ -50,7 +50,7 @@ import Test.Tasty.Runners (timed)
 import Turtle.Prelude (need)
 
 testLogger :: Logger
-testLogger = noLogging
+testLogger = Logger print Debug
 
 awsMqttConfig :: HostName -> Credential -> CertificateStore -> MQTTGRPCConfig
 awsMqttConfig hostName cred certStore =

--- a/test/Test/ProtoClients.hs
+++ b/test/Test/ProtoClients.hs
@@ -1,9 +1,8 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TemplateHaskell #-}
 

--- a/test/Test/ProtoClients.hs
+++ b/test/Test/ProtoClients.hs
@@ -12,16 +12,4 @@ module Test.ProtoClients where
 import Network.GRPC.MQTT.TH.Client
 import Proto.Test
 
--- addHelloMqttClient :: MQTTGRPCClient -> Topic -> AddHello MQTTRequest MQTTResult
--- addHelloMqttClient client baseTopic =
---   AddHello
---     (mqttRequest client baseTopic (MethodName "/test.AddHello/Add"))
---     (mqttRequest client baseTopic (MethodName "/test.AddHello/HelloSS"))
-
--- multGoodbyeMqttClient :: MQTTGRPCClient -> Topic -> MultGoodbye MQTTRequest MQTTResult
--- multGoodbyeMqttClient client baseTopic =
---   MultGoodbye
---     (mqttRequest client baseTopic (MethodName "/test.MultGoodbye/Mult"))
---     (mqttRequest client baseTopic (MethodName "/test.MultGoodbye/GoodbyeSS"))
-
 $(mqttClientFuncs "proto/test.proto")

--- a/test/Test/ProtoRemoteClients.hs
+++ b/test/Test/ProtoRemoteClients.hs
@@ -1,9 +1,8 @@
-{- 
+{-
   Copyright (c) 2021 Arista Networks, Inc.
   Use of this source code is governed by the Apache License 2.0
   that can be found in the COPYING file.
 -}
-
 {-# LANGUAGE TemplateHaskell #-}
 
 module Test.ProtoRemoteClients where

--- a/test/Test/ProtoRemoteClients.hs
+++ b/test/Test/ProtoRemoteClients.hs
@@ -11,20 +11,4 @@ module Test.ProtoRemoteClients where
 import Network.GRPC.MQTT.TH.RemoteClient
 import Proto.Test
 
--- addHelloRemoteClientMethodMap :: Client -> IO MethodMap
--- addHelloRemoteClientMethodMap grpcClient = do
---   ah <- addHelloClient grpcClient
---   return $ fromList
---     [ ("/test.AddHello/Add", wrapUnaryClientHandler $ addHelloAdd ah)
---     , ("/test.AddHello/HelloSS", wrapServerStreamingClientHandler $ addHelloHelloSS ah)
---     ]
-
--- multGoodbyeRemoteClientMethodMap :: Client -> IO MethodMap
--- multGoodbyeRemoteClientMethodMap grpcClient = do
---   mg <- multGoodbyeClient grpcClient
---   return $ fromList
---     [ ("/test.MultGoodbye/Mult", wrapUnaryClientHandler $ multGoodbyeMult mg)
---     , ("/test.MultGoodbye/GoodbyeSS", wrapServerStreamingClientHandler $ multGoodbyeGoodbyeSS mg)
---     ]
-
 $(mqttRemoteClientMethodMap "proto/test.proto")


### PR DESCRIPTION
This PR adds support for client streaming gRPC requests. This was a pretty invasive change that necessitated some significant refactoring (which snowballed to include some less significant refactoring as well...). Most of the substantive changes are in the modules `Network.GRPC.MQTT.Client` and `Network.GRPC.MQTT.RemoteClient`

Other key changes:

- Response topics are no longer sent along with message requests and the pre-established response topic pattern will be used: `<baseTopic>/grpc/session/<sessionId>`. This helps to normalize the bi-directional communications, but should also give a significant performance improvement. The remote client can now subscribe to all topics at once on initialization instead of for each incoming request.
- The RemoteClient `Session`s have been overhauled so that now all requests are handled via `Session`s
- Now properly supports arbitrary base topics instead of requiring exactly 2 components.