### PR TITLE
Allow users to create their own client

### DIFF
--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -33,4 +33,8 @@ logDebug :: (MonadIO io) => Logger -> Text -> io ()
 logDebug = logVerbosity Debug
 
 logVerbosity :: (MonadIO io) => Verbosity -> Logger -> Text -> io ()
-logVerbosity v logger msg = when (verbosity logger >= v) $ liftIO (log logger msg)
+logVerbosity v logger msg = do
+  print $ verbosity logger
+  print v
+  print msg
+  when (verbosity logger >= v) $ liftIO (log logger msg)

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -33,8 +33,4 @@ logDebug :: (MonadIO io) => Logger -> Text -> io ()
 logDebug = logVerbosity Debug
 
 logVerbosity :: (MonadIO io) => Verbosity -> Logger -> Text -> io ()
-logVerbosity v logger msg = do
-  print $ verbosity logger
-  print v
-  print msg
-  when (verbosity logger >= v) $ liftIO (log logger msg)
+logVerbosity v logger msg = when (verbosity logger >= v) $ liftIO (log logger msg)

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -5,7 +5,7 @@
 -}
 {-# LANGUAGE RecordWildCards #-}
 
-module Network.GRPC.MQTT.RemoteClient (runRemoteClient) where
+module Network.GRPC.MQTT.RemoteClient (runRemoteClient, runRemoteClient') where
 
 import Relude
 
@@ -116,17 +116,12 @@ runRemoteClient ::
 runRemoteClient logger cfg baseTopic methodMap = do
   sharedSessionMap <- newTVarIO mempty
   let gatewayConfig = cfg{_msgCB = gatewayHandler sharedSessionMap}
+
   bracket (connectMQTT gatewayConfig) normalDisconnect $ \gatewayMQTTClient -> do
     logInfo logger "Connected to MQTT Broker"
 
-    handle (logException "MQTT client connection") $ do
-      let grpcRequestsFilter = toFilter baseTopic <> "grpc" <> "request" <> "+" <> "+" <> "+"
-      let controlFilter = toFilter baseTopic <> "grpc" <> "session" <> "+" <> "control"
-      subscribeOrThrow gatewayMQTTClient [grpcRequestsFilter, controlFilter]
+    runRemoteClient' logger gatewayMQTTClient baseTopic
 
-      waitForClient gatewayMQTTClient
-
-      logInfo logger "MQTT client connection terminated normally"
   where
     gatewayHandler :: SessionMap -> MessageCallback
     gatewayHandler sharedSessionMap = SimpleCallback $ \client topic mqttMessage _props -> do
@@ -163,7 +158,31 @@ runRemoteClient logger cfg baseTopic methodMap = do
               Nothing -> logInfo taggedLogger "Received control message for non-existant session"
               Just session -> controlMsgHandler taggedLogger session mqttMessage
           _ -> logErr logger $ "Failed to parse topic: " <> unTopic topic
+    logException :: Text -> SomeException -> IO ()
+    logException name e =
+      logErr logger $
+        name <> " terminated with exception: " <> toText (displayException e)
 
+
+runRemoteClient' ::
+  Logger ->
+  -- | MQTT configuration for connecting to the MQTT broker
+  MQTTClient ->
+  -- | Base topic which should uniquely identify the device
+  Topic ->
+  -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
+  IO ()
+runRemoteClient' logger gatewayMQTTClient baseTopic  = do
+
+  handle (logException "MQTT client connection") $ do
+    let grpcRequestsFilter = toFilter baseTopic <> "grpc" <> "request" <> "+" <> "+" <> "+"
+    let controlFilter = toFilter baseTopic <> "grpc" <> "session" <> "+" <> "control"
+    subscribeOrThrow gatewayMQTTClient [grpcRequestsFilter, controlFilter]
+
+    waitForClient gatewayMQTTClient
+
+    logInfo logger "MQTT client connection terminated normally"
+  where
     logException :: Text -> SomeException -> IO ()
     logException name e =
       logErr logger $

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -119,12 +119,11 @@ runRemoteClient logger cfg baseTopic methodMap = do
 runRemoteClient' ::
   Logger ->
   -- | MQTT configuration for connecting to the MQTT broker
-  -- | MQTT configuration for connecting to the MQTT broker
   MQTTGRPCConfig ->
+  -- | A function that creates a client for us to use
   (MQTTGRPCConfig -> IO MQTTClient) ->
   -- | Base topic which should uniquely identify the device
   Topic ->
-  -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   MethodMap ->
   IO ()

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -132,6 +132,7 @@ runRemoteClient' logger cfg connect baseTopic methodMap = do
   sharedSessionMap <- newTVarIO mempty
   let gatewayConfig = cfg{_msgCB = gatewayHandler sharedSessionMap}
 
+  logInfo logger "Connecting to MQTT Broker"
   bracket (connect gatewayConfig) normalDisconnect $ \gatewayMQTTClient -> do
     logInfo logger "Connected to MQTT Broker"
 

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -5,7 +5,7 @@
 -}
 {-# LANGUAGE RecordWildCards #-}
 
-module Network.GRPC.MQTT.RemoteClient (runRemoteClient, runRemoteClient') where
+module Network.GRPC.MQTT.RemoteClient (runRemoteClient, runRemoteClientWithConnect) where
 
 import Relude
 
@@ -113,21 +113,20 @@ runRemoteClient ::
   -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   MethodMap ->
   IO ()
-runRemoteClient logger cfg baseTopic methodMap = do
-  runRemoteClient' logger cfg connectMQTT baseTopic methodMap
+runRemoteClient = runRemoteClientWithConnect connectMQTT
 
-runRemoteClient' ::
+runRemoteClientWithConnect ::
+  -- | A function that creates a client for us to use
+  (MQTTGRPCConfig -> IO MQTTClient) ->
   Logger ->
   -- | MQTT configuration for connecting to the MQTT broker
   MQTTGRPCConfig ->
-  -- | A function that creates a client for us to use
-  (MQTTGRPCConfig -> IO MQTTClient) ->
   -- | Base topic which should uniquely identify the device
   Topic ->
   -- | A map from gRPC method names to functions that can make requests to an appropriate gRPC server
   MethodMap ->
   IO ()
-runRemoteClient' logger cfg connect baseTopic methodMap = do
+runRemoteClientWithConnect connect logger cfg baseTopic methodMap = do
   sharedSessionMap <- newTVarIO mempty
   let gatewayConfig = cfg{_msgCB = gatewayHandler sharedSessionMap}
 


### PR DESCRIPTION
This exposes another `runRemoteClient` that let's a consumer create their own client. This enables whatever networking shenanigans they need in their environment.