### PR TITLE
Escape dots in service names

### DIFF
--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -49,6 +49,8 @@ import Crypto.Nonce qualified as Nonce
 
 import Data.ByteString qualified as ByteString
 
+import Data.Text qualified as Text
+
 import Network.GRPC.HighLevel
   ( GRPCIOError (GRPCIOTimeout),
     MethodName (MethodName),
@@ -446,16 +448,16 @@ makeMethodRequestTopic baseTopic sid (MethodName nm) =
   -- Some MQTT implementations (for e.g. RabbitMQ) can't handle dots
   -- in topic names. We replace them with hyphens. This is unambiguous
   -- because hyphens cannot occur in method names.
-  let escapeDots :: Word8 -> Word8
-      escapeDots c
-        | c == fromIntegral (ord '.') = fromIntegral (ord '-')
-        | otherwise = c
+  let escapeDots :: Text -> Text
+      escapeDots = Text.map \case
+        '.' -> '-'
+        c -> c
 
       -- The leading '/' character is removed via @drop 1@ since the 'Semigroup'
       -- instance for 'Topic' automatically inserts '/' slashes when joining
       -- topics.
       methodTopic :: Maybe Topic
-      methodTopic = mkTopic . decodeUtf8 . ByteString.map escapeDots . ByteString.drop 1 $ nm
+      methodTopic = mkTopic . escapeDots . decodeUtf8 . ByteString.drop 1 $ nm
    in case methodTopic of
         Nothing -> throwIO (BadRPCMethodTopicError (decodeUtf8 nm))
         Just ts -> pure (baseTopic <> "grpc" <> "request" <> sid <> ts)

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -434,7 +434,7 @@ makeSessionIdTopic gen = do
 -- if the 'MethodName' provided would not form a valid MQTT topic.
 --
 -- >>> makeMethodRequestTopic "base.topic" "BgHY9DxnsLj7-IEq4IxTgqMg" "/proto.package.ServiceName/MyRPC"
--- Topic {unTopic = "base.topic/grpc/request/BgHY9DxnsLj7-IEq4IxTgqMg/proto.package.ServiceName/MyRPC"}
+-- Topic {unTopic = "base.topic/grpc/request/BgHY9DxnsLj7-IEq4IxTgqMg/proto-package-ServiceName/MyRPC"}
 --
 -- >>> -- The method "/bad/#/topic" forms an invalid topic (contains a '#')
 -- >>> makeMethodRequestTopic "..." "..." "/bad/#/topic"
@@ -443,11 +443,19 @@ makeSessionIdTopic gen = do
 -- @since 0.1.0.0
 makeMethodRequestTopic :: Topic -> Topic -> MethodName -> IO Topic
 makeMethodRequestTopic baseTopic sid (MethodName nm) =
-  -- The leading '/' character is removed via @drop 1@ since the 'Semigroup'
-  -- instance for 'Topic' automatically inserts '/' slashes when joining
-  -- topics.
-  let methodTopic :: Maybe Topic
-      methodTopic = mkTopic . decodeUtf8 . ByteString.drop 1 $ nm
+  -- Some MQTT implementations (for e.g. RabbitMQ) can't handle dots
+  -- in topic names. We replace them with hyphens. This is unambiguous
+  -- because hyphens cannot occur in method names.
+  let escapeDots :: Word8 -> Word8
+      escapeDots c
+        | c == fromIntegral (ord '.') = fromIntegral (ord '-')
+        | otherwise = c
+
+      -- The leading '/' character is removed via @drop 1@ since the 'Semigroup'
+      -- instance for 'Topic' automatically inserts '/' slashes when joining
+      -- topics.
+      methodTopic :: Maybe Topic
+      methodTopic = mkTopic . decodeUtf8 . ByteString.map escapeDots . ByteString.drop 1 $ nm
    in case methodTopic of
         Nothing -> throwIO (BadRPCMethodTopicError (decodeUtf8 nm))
         Just ts -> pure (baseTopic <> "grpc" <> "request" <> sid <> ts)

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -356,7 +356,10 @@ fromRqtTopic base topic = do
   ["grpc", "request", sid, escapedSvc, rpc] <- stripPrefix (Topic.split base) (Topic.split topic)
 
   let unescapeDots :: Text -> Text
-      unescapeDots = Text.map (\c -> if c == '-' then '.' else c)
+      unescapeDots =
+        Text.map \case
+          '-' -> '.'
+          c -> c
 
   svc <- Topic.mkTopic $ unescapeDots $ Topic.unTopic escapedSvc
   pure (SessionTopic base sid svc rpc)

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -85,6 +85,8 @@ import Data.Time.Clock (NominalDiffTime)
 import Data.HashMap.Strict qualified as HashMap
 import Data.List (stripPrefix)
 
+import Data.Text qualified as Text
+
 import Language.Haskell.TH.Syntax (Name)
 import Language.Haskell.TH.Syntax qualified as TH.Syntax
 
@@ -351,5 +353,10 @@ data SessionTopic = SessionTopic
 -- @since 0.1.0.0
 fromRqtTopic :: Topic -> Topic -> Maybe SessionTopic
 fromRqtTopic base topic = do
-  ["grpc", "request", sid, svc, rpc] <- stripPrefix (Topic.split base) (Topic.split topic)
+  ["grpc", "request", sid, escapedSvc, rpc] <- stripPrefix (Topic.split base) (Topic.split topic)
+
+  let unescapeDots :: Text -> Text
+      unescapeDots = Text.map (\c -> if c == '-' then '.' else c)
+
+  svc <- Topic.mkTopic $ unescapeDots $ Topic.unTopic escapedSvc
   pure (SessionTopic base sid svc rpc)


### PR DESCRIPTION
RabbitMQ does not support dots in topic names. Fully qualified service
names usually have dot characters in it and need to be escaped before
using as a topic name in the client and unescaped in the remote client.

I used hyphen as a replacement because hyphens are not valid
identifier characters according to protobuf specification.