### PR TITLE
Support proto3-suite 0.5.0 and later.

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -95,6 +95,7 @@ library
     Network.GRPC.MQTT.Message.Packet.Core
     Network.GRPC.MQTT.Message.Request.Core
     Proto.Mqtt
+    Proto3.Suite.DotProto.Internal.Compat
     Proto3.Wire.Decode.Extra
     Proto3.Wire.Encode.Extra
     Proto3.Wire.Types.Extra

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -7,7 +7,7 @@ synopsis:    Run gRPC services over an MQTT connection
 license:     Apache-2.0
 author:      Arista Networks
 maintainer:  opensource@awakesecurity.com
-copyright:   2021 Arista Networks
+copyright:   2021-2022 Arista Networks
 category:    Network
 build-type:  Simple
 

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2021 Arista Networks, Inc.
+-- Copyright (c) 2021-2022 Arista Networks, Inc.
 -- Use of this source code is governed by the Apache License 2.0
 -- that can be found in the COPYING file.
 {-# LANGUAGE TemplateHaskell #-}

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -48,7 +48,7 @@ import Turtle (FilePath)
 mqttClientFuncs :: Turtle.FilePath -> Batched -> Q [Dec]
 mqttClientFuncs fp defaultBatchedStream = fmap concat $
   forEachService fp defaultBatchedStream $ \serviceName serviceMethods -> do
-    clientFuncName <- mkName <$> prefixedMethodName serviceName "mqttClient"
+    clientFuncName <- mkName <$> prefixedMethodName serviceName "MqttClient"
     lift $ clientService clientFuncName (mkName serviceName) [(a, batched) | (a, batched, _, _) <- serviceMethods]
 
 clientService :: Name -> Name -> [(String, Batched)] -> DecsQ

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -40,7 +40,7 @@ import Network.GRPC.MQTT.Types
     MQTTResult,
   )
 import Network.MQTT.Topic (Topic)
-import Proto3.Suite.DotProto.Internal (prefixedFieldName)
+import Proto3.Suite.DotProto.Internal.Compat (prefixedMethodName)
 import Turtle (FilePath)
 
 --------------------------------------------------------------------------------
@@ -48,7 +48,7 @@ import Turtle (FilePath)
 mqttClientFuncs :: Turtle.FilePath -> Batched -> Q [Dec]
 mqttClientFuncs fp defaultBatchedStream = fmap concat $
   forEachService fp defaultBatchedStream $ \serviceName serviceMethods -> do
-    clientFuncName <- mkName <$> prefixedFieldName serviceName "mqttClient"
+    clientFuncName <- mkName <$> prefixedMethodName serviceName "mqttClient"
     lift $ clientService clientFuncName (mkName serviceName) [(a, batched) | (a, batched, _, _) <- serviceMethods]
 
 clientService :: Name -> Name -> [(String, Batched)] -> DecsQ

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -1,7 +1,6 @@
 -- Copyright (c) 2021-2022 Arista Networks, Inc.
 -- Use of this source code is governed by the Apache License 2.0
 -- that can be found in the COPYING file.
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -48,13 +47,8 @@ import Proto3.Suite.DotProto.Internal
     protoPackageName,
     typeLikeName,
   )
+import Proto3.Suite.DotProto.Internal.Compat (prefixedMethodName)
 import Turtle (FilePath, directory, filename)
-
-#if MIN_VERSION_proto3_suite(0,5,0)
-import Proto3.Suite.DotProto.Internal (prefixedMethodName)
-#else
-import Proto3.Suite.DotProto.Internal (prefixedFieldName)
-#endif
 
 -------------------------------------------------------------------------------
 
@@ -109,13 +103,7 @@ forEachService protoFilepath defBatchedStream action = showErrors . runExceptT $
                       (NonStreaming, NonStreaming) -> [e|wrapUnaryClientHandler|]
                       (Streaming, NonStreaming) -> [e|wrapClientStreamingClientHandler|]
                       (Streaming, Streaming) -> [e|wrapBiDiStreamingClientHandler useBatchedStream|]
-              clientFun <-
-#if MIN_VERSION_proto3_suite(0,5,0)
-                prefixedMethodName
-#else
-                prefixedFieldName
-#endif
-                serviceName nm
+              clientFun <- prefixedMethodName serviceName nm
               return [(endpointPrefix <> nm, useBatchedStream, streamingWrapper, mkName clientFun)]
             _ -> invalidMethodNameError rpcMethodName
         serviceMethodName _ = pure []

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -1,6 +1,7 @@
--- Copyright (c) 2021 Arista Networks, Inc.
+-- Copyright (c) 2021-2022 Arista Networks, Inc.
 -- Use of this source code is governed by the Apache License 2.0
 -- that can be found in the COPYING file.
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -44,11 +45,16 @@ import Proto3.Suite.DotProto.Internal
     dpIdentUnqualName,
     importProto,
     invalidMethodNameError,
-    prefixedFieldName,
     protoPackageName,
     typeLikeName,
   )
 import Turtle (FilePath, directory, filename)
+
+#if MIN_VERSION_proto3_suite(0,5,0)
+import Proto3.Suite.DotProto.Internal (prefixedMethodName)
+#else
+import Proto3.Suite.DotProto.Internal (prefixedFieldName)
+#endif
 
 -------------------------------------------------------------------------------
 
@@ -103,7 +109,13 @@ forEachService protoFilepath defBatchedStream action = showErrors . runExceptT $
                       (NonStreaming, NonStreaming) -> [e|wrapUnaryClientHandler|]
                       (Streaming, NonStreaming) -> [e|wrapClientStreamingClientHandler|]
                       (Streaming, Streaming) -> [e|wrapBiDiStreamingClientHandler useBatchedStream|]
-              clientFun <- prefixedFieldName serviceName nm
+              clientFun <-
+#if MIN_VERSION_proto3_suite(0,5,0)
+                prefixedMethodName
+#else
+                prefixedFieldName
+#endif
+                serviceName nm
               return [(endpointPrefix <> nm, useBatchedStream, streamingWrapper, mkName clientFun)]
             _ -> invalidMethodNameError rpcMethodName
         serviceMethodName _ = pure []

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -1,4 +1,4 @@
--- Copyright (c) 2021 Arista Networks, Inc.
+-- Copyright (c) 2021-2022 Arista Networks, Inc.
 -- Use of this source code is governed by the Apache License 2.0
 -- that can be found in the COPYING file.
 {-# LANGUAGE TemplateHaskell #-}

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -43,8 +43,8 @@ import Turtle (FilePath)
 mqttRemoteClientMethodMap :: Turtle.FilePath -> Batched -> Q [Dec]
 mqttRemoteClientMethodMap fp defaultBatchedStream = fmap concat $
   forEachService fp defaultBatchedStream $ \serviceName serviceMethods -> do
-    clientFuncName <- mkName <$> prefixedMethodName serviceName "remoteClientMethodMap"
-    grpcClientName <- mkName <$> prefixedMethodName serviceName "client"
+    clientFuncName <- mkName <$> prefixedMethodName serviceName "RemoteClientMethodMap"
+    grpcClientName <- mkName <$> prefixedMethodName serviceName "Client"
     lift $ rcMethodMap clientFuncName grpcClientName serviceMethods
 
 rcMethodMap :: Name -> Name -> [(String, Batched, ExpQ, Name)] -> DecsQ

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -35,7 +35,7 @@ import Language.Haskell.TH
 import Network.GRPC.HighLevel.Client (Client)
 import Network.GRPC.MQTT.Types (Batched (Batched, Unbatched), MethodMap)
 import Network.GRPC.MQTT.Wrapping (wrapServerStreamingClientHandler, wrapUnaryClientHandler)
-import Proto3.Suite.DotProto.Internal (prefixedFieldName)
+import Proto3.Suite.DotProto.Internal.Compat (prefixedMethodName)
 import Turtle (FilePath)
 
 --------------------------------------------------------------------------------
@@ -43,8 +43,8 @@ import Turtle (FilePath)
 mqttRemoteClientMethodMap :: Turtle.FilePath -> Batched -> Q [Dec]
 mqttRemoteClientMethodMap fp defaultBatchedStream = fmap concat $
   forEachService fp defaultBatchedStream $ \serviceName serviceMethods -> do
-    clientFuncName <- mkName <$> prefixedFieldName serviceName "remoteClientMethodMap"
-    grpcClientName <- mkName <$> prefixedFieldName serviceName "client"
+    clientFuncName <- mkName <$> prefixedMethodName serviceName "remoteClientMethodMap"
+    grpcClientName <- mkName <$> prefixedMethodName serviceName "client"
     lift $ rcMethodMap clientFuncName grpcClientName serviceMethods
 
 rcMethodMap :: Name -> Name -> [(String, Batched, ExpQ, Name)] -> DecsQ

--- a/src/Proto3/Suite/DotProto/Internal/Compat.hs
+++ b/src/Proto3/Suite/DotProto/Internal/Compat.hs
@@ -15,7 +15,9 @@ import Proto3.Suite.DotProto.Internal (prefixedMethodName)
 
 #else
 
-import Proto3.Suite.DotProto.Internal (prefixedFieldName)
+import Control.Monad.Except (MonadError)
+import Proto3.Suite.DotProto.Internal (CompileError, prefixedFieldName)
+import Relude (String)
 
 prefixedMethodName :: MonadError CompileError m => String -> String -> m String
 prefixedMethodName = prefixedFieldName

--- a/src/Proto3/Suite/DotProto/Internal/Compat.hs
+++ b/src/Proto3/Suite/DotProto/Internal/Compat.hs
@@ -1,0 +1,23 @@
+-- Copyright (c) 2022 Arista Networks, Inc.
+-- Use of this source code is governed by the Apache License 2.0
+-- that can be found in the COPYING file.
+{-# LANGUAGE CPP #-}
+
+-- | For versions of @proto3-suite@ starting with 0.5.0, merely
+-- reexports `Proto3.Suite.DotProto.Internal.prefixedMethodName)`,
+-- but for earlier versions emulates that function by defining it as
+-- an alias of `Proto3.Suite.DotProto.Internal.prefixedFieldName`.
+module Proto3.Suite.DotProto.Internal.Compat (prefixedMethodName) where
+
+#if MIN_VERSION_proto3_suite(0,5,0)
+
+import Proto3.Suite.DotProto.Internal (prefixedMethodName)
+
+#else
+
+import Proto3.Suite.DotProto.Internal (prefixedFieldName)
+
+prefixedMethodName :: MonadError CompileError m => String -> String -> m String
+prefixedMethodName = prefixedFieldName
+
+#endif


### PR DESCRIPTION
Starting with proto3-suite 0.5.0, the initial character of
a service method names is no longer forced to uppercase.