### PR TITLE
Remove reference to test.proto

### DIFF
--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -65,7 +65,6 @@ in {
               cp -r ${proto-files}/. $out/proto/.
               cd $out
               ${haskellPackagesNew.proto3-suite}/bin/compile-proto-file --proto proto/mqtt.proto --out $out
-              ${haskellPackagesNew.proto3-suite}/bin/compile-proto-file --proto proto/test.proto --out $out
             '';
 
             copyGeneratedCode = ''


### PR DESCRIPTION
`test.proto` was removed but the nix configuration was not updated accordingly.