### PR TITLE
Add files exposing protobuf options. 

### DIFF
--- a/proto/README.md
+++ b/proto/README.md
@@ -23,8 +23,8 @@ message Response {
 }
 
 service ExampleService {
-  // Enables zstandard compression with a compression level 10 for all RPCs in 
-  // this service.
+  // Enables response compression (via zstandard) with a compression level 10 
+  // for all RPCs in this service..
   option (haskell.grpc.mqtt.server_clevel_service) = CLEVEL_10;
   
   rpc SayHello(HelloRequest) returns (stream Response);
@@ -36,8 +36,8 @@ service ExampleService {
   }; 
 
   rpc SayGoodbye(HelloRequest) returns (stream Response) {
-    // Overrides the service's default compression level value and disables 
-    // response compression for this method.
+    // Overrides the service's default compression level value for responses and
+    // disables response compression for this method.
     option (haskell.grpc.mqtt.server_clevel) = CLEVEL_DISABLE;
   };
 }

--- a/proto/README.md
+++ b/proto/README.md
@@ -1,0 +1,44 @@
+
+An example of how the protobuf options `grpc-mqtt` supports can be used to change how splices are generated in template haskell functions such as `makeMQTTClientFuncs` or `mqttRemoteClientMethodMap`:
+
+```protobuf
+syntax = "proto3";
+
+import "haskell/grpc/mqtt.proto";
+
+package test;
+
+// Enables batched streaming by default for all RPCs in the file.
+option (haskell.grpc.mqtt.batched_stream_file) = true;
+
+message HelloRequest { }
+
+message TwoDigits {
+  int32 fst_digit = 1;
+  int32 snd_digit = 2;
+}
+
+message Response {
+  string value = 1;
+}
+
+service ExampleService {
+  // Enables zstandard compression with a compression level 10 for all RPCs in 
+  // this service.
+  option (haskell.grpc.mqtt.server_clevel_service) = CLEVEL_10;
+  
+  rpc SayHello(HelloRequest) returns (stream Response);
+
+  rpc AddTwoDigits(TwoDigits) returns (stream Response) { 
+    // Overrides the file's default batched_stream value and disables batching 
+    // for this method's response stream.
+    option (haskell.grpc.mqtt.batched_stream) = true;
+  }; 
+
+  rpc SayGoodbye(HelloRequest) returns (stream Response) {
+    // Overrides the service's default compression level value and disables 
+    // response compression for this method.
+    option (haskell.grpc.mqtt.server_clevel) = CLEVEL_DISABLE;
+  };
+}
+```

--- a/proto/haskell/grpc/mqtt.proto
+++ b/proto/haskell/grpc/mqtt.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+
+import public "haskell/grpc/mqtt/clevel.proto";
+import public "haskell/grpc/mqtt/option.proto";
+
+package haskell.grpc.mqtt;

--- a/proto/haskell/grpc/mqtt/clevel.proto
+++ b/proto/haskell/grpc/mqtt/clevel.proto
@@ -1,0 +1,32 @@
+
+syntax = "proto3";
+
+package haskell.grpc.mqtt;
+
+enum CLevel {
+  option allow_alias = true;
+  CLEVEL_DISABLE = 0;
+  CLEVEL_UNKNOWN = 0;
+  CLEVEL_1 = 1;
+  CLEVEL_2 = 2;
+  CLEVEL_3 = 3;
+  CLEVEL_4 = 4;
+  CLEVEL_5 = 5;
+  CLEVEL_6 = 6;
+  CLEVEL_7 = 7;
+  CLEVEL_8 = 8;
+  CLEVEL_9 = 9;
+  CLEVEL_10 = 10;
+  CLEVEL_11 = 11;
+  CLEVEL_12 = 12;
+  CLEVEL_13 = 13;
+  CLEVEL_14 = 14;
+  CLEVEL_15 = 15;
+  CLEVEL_16 = 16;
+  CLEVEL_17 = 17;
+  CLEVEL_18 = 18;
+  CLEVEL_19 = 19;
+  CLEVEL_20 = 20;
+  CLEVEL_21 = 21;
+  CLEVEL_22 = 22;
+}

--- a/proto/haskell/grpc/mqtt/option.proto
+++ b/proto/haskell/grpc/mqtt/option.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+import "google/protobuf/descriptor.proto";
+import "haskell/grpc/mqtt/clevel.proto";
+
+package haskell.grpc.mqtt;
+
+extend google.protobuf.FileOptions {
+  optional bool batched_stream_file = 50001;
+  optional CLevel server_clevel_file = 50002;
+  optional CLevel client_clevel_file = 50003;
+}
+
+extend google.protobuf.ServiceOptions {
+  optional bool batched_stream_service = 50001;
+  optional CLevel server_clevel_service = 50002;
+  optional CLevel client_clevel_service = 50003;
+}
+
+extend google.protobuf.MethodOptions {
+  optional bool batched_stream = 50001;
+  optional CLevel server_clevel = 50002;
+  optional CLevel client_clevel = 50003;
+}


### PR DESCRIPTION
Adds a few new protos exposing the library's options and a `CLevel` enum that can be used with `protoc`