### PR TITLE
Remove `optional` from options

### DIFF
--- a/proto/haskell/grpc/mqtt/option.proto
+++ b/proto/haskell/grpc/mqtt/option.proto
@@ -6,19 +6,19 @@ import "haskell/grpc/mqtt/clevel.proto";
 package haskell.grpc.mqtt;
 
 extend google.protobuf.FileOptions {
-  optional bool batched_stream_file = 50001;
-  optional CLevel server_clevel_file = 50002;
-  optional CLevel client_clevel_file = 50003;
+  bool batched_stream_file = 50001;
+  CLevel server_clevel_file = 50002;
+  CLevel client_clevel_file = 50003;
 }
 
 extend google.protobuf.ServiceOptions {
-  optional bool batched_stream_service = 50001;
-  optional CLevel server_clevel_service = 50002;
-  optional CLevel client_clevel_service = 50003;
+  bool batched_stream_service = 50001;
+  CLevel server_clevel_service = 50002;
+  CLevel client_clevel_service = 50003;
 }
 
 extend google.protobuf.MethodOptions {
-  optional bool batched_stream = 50001;
-  optional CLevel server_clevel = 50002;
-  optional CLevel client_clevel = 50003;
+  bool batched_stream = 50001;
+  CLevel server_clevel = 50002;
+  CLevel client_clevel = 50003;
 }


### PR DESCRIPTION
Removes the `optional` field annotations from proto option extensions.