### PR TITLE
Factor MVector allocation out of packetization

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -55,7 +55,7 @@ common common
     , grpc-haskell
     , grpc-haskell-core
     , net-mqtt >= 0.8.1
-    , proto3-suite
+    , proto3-suite >= 0.5.1
     , proto3-wire
     , relude
     , text
@@ -147,7 +147,7 @@ test-suite test
   ghc-options:
     -threaded
     -rtsopts
-    -with-rtsopts=-N4 -I2 -qb -qg
+    "-with-rtsopts=-N4 -I2 -qb0 -G1"
     -O2
 
   other-modules:

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -22,6 +22,9 @@ in {
   haskellPackages = pkgsOld.haskell.packages."${compiler}".override (old: {
     overrides = pkgsNew.lib.composeManyExtensions [
       (haskellPackagesNew: haskellPackagesOld: {
+        word-compat = pkgsNew.haskell.lib.dontCheck (haskellPackagesNew.callPackage ../packages/word-compat.nix {});
+      })
+      (haskellPackagesNew: haskellPackagesOld: {
         proto3-suite = pkgsNew.haskell.lib.dontCheck (haskellPackagesNew.callPackage ../packages/proto3-suite.nix {});
         proto3-wire  = haskellPackagesNew.callPackage ../packages/proto3-wire.nix  {};
         grpc-haskell = pkgsNew.haskell.lib.dontCheck (haskellPackagesNew.callPackage ../packages/grpc-haskell.nix {});

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -8,7 +8,7 @@ mkDerivation {
   pname = "grpc-haskell";
   version = "0.3.0";
   src = fetchgit {
-    url = "https://github.com/awakesecurity/grpc-haskell.git";
+    url = "https://github.com/awakesecurity/gRPC-haskell";
     sha256 = "05s3p5xidfdqh3vghday62pscl968vx9r3xmqhs037a8ark3gr6h";
     rev = "112777023f475ddd752c954056e679fbca0baa44";
     fetchSubmodules = true;

--- a/nix/packages/proto3-suite.nix
+++ b/nix/packages/proto3-suite.nix
@@ -1,21 +1,21 @@
 { mkDerivation, aeson, aeson-pretty, attoparsec, base
 , base64-bytestring, binary, bytestring, cereal, containers
 , contravariant, deepseq, doctest, fetchgit, filepath, foldl
-, generic-arbitrary, hashable, haskell-src
+, generic-arbitrary, hashable, haskell-src, hedgehog
 , insert-ordered-containers, lens, lib, mtl, neat-interpolation
 , optparse-applicative, optparse-generic, parsec, parsers, pretty
 , pretty-show, proto3-wire, QuickCheck, quickcheck-instances
-, range-set-list, safe, swagger2, system-filepath, tasty
-, tasty-hunit, tasty-quickcheck, text, time, transformers, turtle
-, vector
+, range-set-list, safe, split, swagger2, system-filepath, tasty
+, tasty-hedgehog, tasty-hunit, tasty-quickcheck, text, time
+, transformers, turtle, vector
 }:
 mkDerivation {
   pname = "proto3-suite";
-  version = "0.4.3";
+  version = "0.5.2";
   src = fetchgit {
-    url = "https://github.com/awakesecurity/proto3-suite.git";
-    sha256 = "0bjqczi6wddxv0n7qmfbrr19ajgq66xdkxx8vfcgbmv8ygma3vlw";
-    rev = "7af7d76dcf9cc71ddada3aa4a38abf46f65550ca";
+    url = "https://github.com/awakesecurity/proto3-suite";
+    sha256 = "1jb1g1d3g8k5kamzkd50ah49qslmxnhh2mwmryl3qvs42law8cmw";
+    rev = "d002df86b0e62e90f2b9bba895ef29c2a16c9d36";
     fetchSubmodules = true;
   };
   isLibrary = true;
@@ -26,8 +26,8 @@ mkDerivation {
     bytestring cereal containers contravariant deepseq filepath foldl
     hashable haskell-src insert-ordered-containers lens mtl
     neat-interpolation parsec parsers pretty pretty-show proto3-wire
-    QuickCheck quickcheck-instances safe swagger2 system-filepath text
-    time transformers turtle vector
+    QuickCheck quickcheck-instances safe split swagger2 system-filepath
+    text time transformers turtle vector
   ];
   executableHaskellDepends = [
     base containers mtl optparse-applicative optparse-generic
@@ -35,9 +35,10 @@ mkDerivation {
   ];
   testHaskellDepends = [
     aeson attoparsec base base64-bytestring bytestring cereal
-    containers deepseq doctest generic-arbitrary mtl pretty-show
-    proto3-wire QuickCheck swagger2 tasty tasty-hunit tasty-quickcheck
-    text transformers turtle vector
+    containers deepseq doctest generic-arbitrary hedgehog mtl parsec
+    pretty pretty-show proto3-wire QuickCheck swagger2 tasty
+    tasty-hedgehog tasty-hunit tasty-quickcheck text transformers
+    turtle vector
   ];
   description = "A higher-level API to the proto3-wire library";
   license = lib.licenses.asl20;

--- a/nix/packages/proto3-wire.nix
+++ b/nix/packages/proto3-wire.nix
@@ -1,21 +1,28 @@
-{ mkDerivation, base, bytestring, cereal, containers, deepseq
-, doctest, ghc-prim, hashable, lib, parameterized, primitive
-, QuickCheck, safe, tasty, tasty-hunit, tasty-quickcheck, text
-, transformers, unordered-containers, vector
+{ mkDerivation, base, bytestring, cereal, containers, criterion
+, deepseq, doctest, fetchgit, ghc-prim, hashable, lib
+, parameterized, primitive, QuickCheck, random, safe, tasty
+, tasty-hunit, tasty-quickcheck, text, transformers
+, unordered-containers, vector, word-compat
 }:
 mkDerivation {
   pname = "proto3-wire";
-  version = "1.2.2";
-  sha256 = "8d409536a89a0187f0576711966d2ef45d43acab7b6a3a1c5ee12f6d01adbfb9";
+  version = "1.4.0";
+  src = fetchgit {
+    url = "https://github.com/awakesecurity/proto3-wire";
+    sha256 = "1pr078k7j5yvsixh7g76bfb3w5a5nxsjl9lgvc5ji4nm0ngx5i61";
+    rev = "ae24c00c83cbce29750005b1fa6506c1e62e4822";
+    fetchSubmodules = true;
+  };
   libraryHaskellDepends = [
     base bytestring cereal containers deepseq ghc-prim hashable
     parameterized primitive QuickCheck safe text transformers
-    unordered-containers vector
+    unordered-containers vector word-compat
   ];
   testHaskellDepends = [
     base bytestring cereal doctest QuickCheck tasty tasty-hunit
     tasty-quickcheck text transformers vector
   ];
+  benchmarkHaskellDepends = [ base bytestring criterion random ];
   description = "A low-level implementation of the Protocol Buffers (version 3) wire format";
   license = lib.licenses.asl20;
 }

--- a/nix/packages/word-compat.nix
+++ b/nix/packages/word-compat.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, ghc-prim, lib }:
+mkDerivation {
+  pname = "word-compat";
+  version = "0.0.2";
+  sha256 = "36e5a1a17f20935f55bf274fb52cbb028d301fd48d814f574d3171ccc6bc9f98";
+  libraryHaskellDepends = [ base ghc-prim ];
+  description = "Compatibility shim for the Int/Word internal change in GHC 9.2";
+  license = lib.licenses.bsd3;
+}

--- a/test/Proto/Service.proto
+++ b/test/Proto/Service.proto
@@ -28,16 +28,16 @@ service TestService {
 
   /* Server Streaming with batching */
   rpc BatchServerStreamCall(StreamRequest) returns (stream StreamReply) {
-    option haskell.grpc.mqtt.batched_stream = true;
+    option (haskell.grpc.mqtt.batched_stream) = true;
   }
 
   /* Client Streaming with batching */
   rpc BatchClientStreamCall (stream OneInt) returns (OneInt) {
-    option haskell.grpc.mqtt.batched_stream = true;
+    option (haskell.grpc.mqtt.batched_stream) = true;
   }
 
   /* BiDi streaming with batching: ping-pong echo */
   rpc BatchBiDiStreamCall(stream BiDiRequestReply) returns (stream BiDiRequestReply) {
-    option haskell.grpc.mqtt.batched_stream = true;
+    option (haskell.grpc.mqtt.batched_stream) = true;
   }
 }

--- a/test/Test/Network/GRPC/MQTT/Message/Packet.hs
+++ b/test/Test/Network/GRPC/MQTT/Message/Packet.hs
@@ -219,7 +219,7 @@ mockHandlePacket encodeOptions decodeOptions = do
   Right message === result
 
 mockPublish :: TChan LByteString -> ByteString -> IO ()
-mockPublish channel message = atomically do
+mockPublish channel message = do
   let message' :: LByteString
       message' = fromStrict @LByteString @ByteString message
-   in writeTChan channel message'
+   in atomically (writeTChan channel message')


### PR DESCRIPTION
Avoids allocating and freezing a `MVector` of packets before each packet is published. This should help reduce GC pressure in larger services. 