### PR TITLE
Remove `Batched` from `mqttRemoteClientMethodMap`

### DIFF
--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -237,13 +237,13 @@ handleRequest handle = do
             let sender = makeClientStreamSender channel options
             k timeout metadata (runIO . sender)
           publishClientResponse encodeOptions result
-        ClientServerStreamHandler _ k -> do
+        ClientServerStreamHandler k -> do
           result <- withRunInIO \runIO -> do
             k message timeout metadata \_ ms recv -> runIO do
               publishPackets encodeOptions (toStrict $ wireEncodeMetadataMap ms)
               makeServerStreamReader encodeOptions recv
           publishClientResponse encodeOptions result
-        ClientBiDiStreamHandler _ k -> do
+        ClientBiDiStreamHandler k -> do
           result <- withRunInIO \runIO -> do
             k timeout metadata \_ ms recv send done -> runIO do
               publishPackets encodeOptions (toStrict $ wireEncodeMetadataMap ms)

--- a/src/Network/GRPC/MQTT/Types.hs
+++ b/src/Network/GRPC/MQTT/Types.hs
@@ -45,10 +45,6 @@ import Text.Show qualified as Show
 
 --------------------------------------------------------------------------------
 
-import Network.GRPC.MQTT.Option.Batched (Batched)
-
---------------------------------------------------------------------------------
-
 -- | Represents the session ID for a request
 type SessionId = Text
 
@@ -131,11 +127,9 @@ data ClientHandler where
     ClientHandler
   ClientServerStreamHandler ::
     (Message response) =>
-    Batched ->
     (ByteString -> TimeoutSeconds -> MetadataMap -> (ClientCall -> MetadataMap -> StreamRecv response -> IO ()) -> IO (ClientResult 'ServerStreaming response)) ->
     ClientHandler
   ClientBiDiStreamHandler ::
     (Message request, Message response) =>
-    Batched ->
     (TimeoutSeconds -> MetadataMap -> (ClientCall -> MetadataMap -> StreamRecv response -> StreamSend request -> WritesDone -> IO ()) -> IO (ClientResult 'BiDiStreaming response)) ->
     ClientHandler

--- a/src/Network/GRPC/MQTT/Wrapping.hs
+++ b/src/Network/GRPC/MQTT/Wrapping.hs
@@ -79,9 +79,6 @@ import Proto3.Wire.Decode (ParseError (..))
 
 ---------------------------------------------------------------------------------
 
-import Network.GRPC.MQTT.Option.Batched (Batched)
-
----------------------------------------------------------------------------------
 
 -- Client Handler Wrappers
 wrapUnaryClientHandler ::
@@ -96,11 +93,10 @@ wrapUnaryClientHandler handler =
 
 wrapServerStreamingClientHandler ::
   (Message request, Message response) =>
-  Batched ->
   (ClientRequest 'ServerStreaming request response -> IO (ClientResult 'ServerStreaming response)) ->
   ClientHandler
-wrapServerStreamingClientHandler useBatchedStream handler =
-  ClientServerStreamHandler useBatchedStream $ \rawRequest timeout metadata recv ->
+wrapServerStreamingClientHandler handler =
+  ClientServerStreamHandler \rawRequest timeout metadata recv ->
     case fromByteString rawRequest of
       Left err -> pure $ ClientErrorResponse (ClientErrorNoParse err)
       Right req -> handler (ClientReaderRequest req timeout metadata recv)
@@ -115,11 +111,10 @@ wrapClientStreamingClientHandler handler =
 
 wrapBiDiStreamingClientHandler ::
   (Message request, Message response) =>
-  Batched ->
   (ClientRequest 'BiDiStreaming request response -> IO (ClientResult 'BiDiStreaming response)) ->
   ClientHandler
-wrapBiDiStreamingClientHandler useBatchedStream handler =
-  ClientBiDiStreamHandler useBatchedStream $ \timeout metadata bidi -> do
+wrapBiDiStreamingClientHandler handler =
+  ClientBiDiStreamHandler \timeout metadata bidi -> do
     handler (ClientBiDiRequest timeout metadata bidi)
 
 -- Utilities

--- a/test/Test/Proto/RemoteClients.hs
+++ b/test/Test/Proto/RemoteClients.hs
@@ -37,4 +37,4 @@ import Proto.Service
 
 ---------------------------------------------------------------------------------
 
-$(mqttRemoteClientMethodMap "test/Proto/Service.proto" Unbatched)
+$(mqttRemoteClientMethodMap "test/Proto/Service.proto")


### PR DESCRIPTION
As pointed out in issue #31, the `Batched` argument given to `mqttRemoteClientMethodMap` was unused. This PR removes the `Batched` argument from `mqttRemoteClientMethodMap` and other places where it was previously unused, like `Network.GRPC.MQTT.Types.ClientHandler`.