### PR TITLE
Reuse threads in packet sender 

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -147,7 +147,7 @@ test-suite test
   ghc-options:
     -threaded
     -rtsopts
-    "-with-rtsopts=-N4 -I2 -qb0 -G1"
+    "-with-rtsopts=-N4"
     -O2
 
   other-modules:

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -44,7 +44,7 @@ main =
 testTree :: TestTree
 testTree =
   testGroup
-    "Tests: grpc-mqtt"
+    "Test"
     [ Test.Network.GRPC.HighLevel.Extra.tests
     , Test.Network.GRPC.MQTT.tests
     , Test.Service.tests

--- a/test/Test/Network/GRPC/MQTT/Message.hs
+++ b/test/Test/Network/GRPC/MQTT/Message.hs
@@ -16,7 +16,7 @@ import Test.Network.GRPC.MQTT.Message.Stream qualified
 tests :: TestTree
 tests =
   testGroup
-    "Network.GRPC.MQTT.Message"
+    "Message"
     [ Test.Network.GRPC.MQTT.Message.Packet.tests
     , Test.Network.GRPC.MQTT.Message.Request.tests
     , Test.Network.GRPC.MQTT.Message.Stream.tests

--- a/test/Test/Service.hs
+++ b/test/Test/Service.hs
@@ -98,12 +98,12 @@ import qualified Data.Map.Strict as Map
 tests :: TestTree
 tests =
   testGroup
-    "Test.Service"
+    "Service"
     [ after Test.AllSucceed "MQTT" testTreeNormal
-    , after Test.AllSucceed "Test.Service.Normal" testTreeClientStream
-    , after Test.AllSucceed "Test.Service.ClientStream" testTreeServerStream
-    , after Test.AllSucceed "Test.Service.ServerStream" testTreeBiDiStream
-    , after Test.AllSucceed "Test.Service.BiDiStream" testTreeErrors
+    , after Test.AllSucceed "Normal" testTreeClientStream
+    , after Test.AllSucceed "ClientStream" testTreeServerStream
+    , after Test.AllSucceed "ServerStream" testTreeBiDiStream
+    , after Test.AllSucceed "BiDiStream" testTreeErrors
     ]
 
 withTestService :: (Async () -> IO a) -> Fixture a
@@ -155,16 +155,6 @@ testCallLongBytes = do
       methods <- testServiceRemoteClientMethodMap grpcClient
       results <- Async.withAsync (runRemoteClient logger remoteConfig baseTopic methods) \_ -> do
 
-        _ <- Async.async do
-          withMQTTGRPCClient logger clientConfig \client ->
-            Async.replicateConcurrently 8 do
-              uuid <- UUID.nextRandom
-
-              let msg = Message.OneInt 8
-              let rqt = GRPC.MQTT.MQTTNormalRequest msg 8 (GRPC.Client.MetadataMap (Map.fromList [("rqt-uuid", [UUID.toASCIIBytes uuid])]))
-
-              testServicecallLongBytes (testServiceMqttClient client baseTopic) rqt
-
         withMQTTGRPCClient logger clientConfig \client ->
           Async.replicateConcurrently 8 do
 
@@ -204,7 +194,7 @@ testNormalCall = do
 testTreeClientStream :: TestTree
 testTreeClientStream =
   testGroup
-    "Test.Service.ClientStream"
+    "ClientStream"
     [ Suite.testFixture "Test.Service.ClientStream.Unbatched" testClientStreamCall
     , after
         Test.AllSucceed
@@ -234,7 +224,7 @@ testBatchClientStreamCall = do
 testTreeServerStream :: TestTree
 testTreeServerStream =
   testGroup
-    "Test.Service.ServerStream"
+    "ServerStream"
     [ Suite.testFixture "Test.Service.ServerStream.Unbatched" testServerStreamCall
     , after
         Test.AllSucceed
@@ -271,7 +261,7 @@ testBatchServerStreamCall = do
 testTreeBiDiStream :: TestTree
 testTreeBiDiStream =
   testGroup
-    "Test.Service.BiDiStream"
+    "BiDiStream"
     [ Suite.testFixture "Test.Service.BiDiStream.Unbatched" testBiDiStreamCall
     , after
         Test.AllSucceed


### PR DESCRIPTION
This PR replaces the `forConcurrently_` usage in `makePacketSender` with `replicateConcurrently_` and a semaphore. This change impacts how threads are used in the `makePacketSender` function. Previously, using `forConcurrently_` would create a new thread for each packet to be published, which performs well but incurs a lot of GC pressure due to each thread being allocated an initial GHC stack size and subsequent stack segments extensions to execute serialization and publishing. 

Running the `"LongBytes"` tests with `-N4 -hT` shows that `19mb` need to be allocated to the GHC stack to split the `BytesResponse` message into packets with `forConcurrently_`:   

![test-for-concurrently](https://user-images.githubusercontent.com/8868893/183785034-fec33edb-c0d1-4263-a80d-d82756b0954e.svg)
 
Most of this is excess stack segment allocations that are never used. The changes in this PR avoids the excess allocations for GHC stack segments by reusing a fixed number of threads (bounded by `getNumCapabilities`) to perform packetization, reducing overall stack allocations by about `~16mb`:

![test](https://user-images.githubusercontent.com/8868893/183785738-06f713f8-4e57-41f7-8b35-2e30eded7420.svg)
 