### PR TITLE
Increase watchdog timeout

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -147,7 +147,7 @@ test-suite test
   ghc-options:
     -threaded
     -rtsopts
-    "-with-rtsopts=-N4 -I2 -qb0 -G1"
+    "-with-rtsopts=-N4"
     -O2
 
   other-modules:

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -72,6 +72,7 @@ import Network.GRPC.HighLevel.Extra (wireEncodeMetadataMap)
 import Network.GRPC.MQTT.Core
   ( MQTTGRPCConfig (mqttMsgSizeLimit, _msgCB),
     connectMQTT,
+    heartbeatPeriodSeconds,
     subscribeOrThrow,
   )
 
@@ -189,7 +190,7 @@ handleNewSession config handle = handleWithHeartbeat
 
     runHeartbeat :: IO ()
     runHeartbeat = do
-      let period'sec = 1 + defaultWatchdogPeriodSec
+      let period'sec = 3 * heartbeatPeriodSeconds
       newWatchdogIO period'sec (hdlHeartbeat handle)
       Logger.logWarn (cfgLogger config) "Watchdog timed out"
 

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -41,7 +41,6 @@ module Network.GRPC.MQTT.RemoteClient.Session
       ),
 
     -- ** Session Watchdog
-    defaultWatchdogPeriodSec,
     newWatchdogIO,
 
     -- * Session Config
@@ -279,15 +278,6 @@ data SessionHandle = SessionHandle
   , hdlRqtChan :: TChan LByteString
   , hdlHeartbeat :: TMVar ()
   }
-
--- | The default watchdog timeout period in seconds.
---
--- >>> defaultWatchdogPeriodSec
--- 10s
---
--- @since 0.1.0.0
-defaultWatchdogPeriodSec :: NominalDiffTime
-defaultWatchdogPeriodSec = 10
 
 -- | Constructs a 'SessionHandle' monitoring from a request handler thread.
 --


### PR DESCRIPTION
Currently, RemoteClient's watchdog only waits 11 seconds for a heart
beat before killing the session while the Client sends a heart beat
every 10 secs. Thus, the RemoteClient ends up terminating requests
aggressively while the Client continues to wait. The fix increases the
RemoteClient timeout value to 3x the Client value so that there is a
sufficient window for delayed heart beats.