### PR TITLE
Prevent wire serialization from exceeding max packet size 

### DIFF
--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -79,7 +79,7 @@ data MQTTGRPCConfig = MQTTGRPCConfig
   { -- | Whether or not to use TLS for the connection
     useTLS :: Bool
   , -- | Maximum size for an MQTT message in bytes
-    mqttMsgSizeLimit :: Int
+    mqttMsgSizeLimit :: Word32
   , -- | Proxy to use to connect to the MQTT broker
     brokerProxy :: Maybe ProxySettings
   , _cleanSession :: Bool

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -78,7 +78,9 @@ import Relude
 data MQTTGRPCConfig = MQTTGRPCConfig
   { -- | Whether or not to use TLS for the connection
     useTLS :: Bool
-  , -- | Maximum size for an MQTT message in bytes
+  , -- | Maximum size for an MQTT message in bytes. This value must be greater 
+    -- than or equal to 16 bytes and less than 256mB, see:
+    -- 'Network.GRPC.MQTT.Message.Packet.makePacketSender'.
     mqttMsgSizeLimit :: Word32
   , -- | Proxy to use to connect to the MQTT broker
     brokerProxy :: Maybe ProxySettings

--- a/src/Network/GRPC/MQTT/Message/Request.hs
+++ b/src/Network/GRPC/MQTT/Message/Request.hs
@@ -333,7 +333,7 @@ makeRequestReader queue = do
 
 makeRequestSender ::
   MonadUnliftIO m =>
-  Int ->
+  Word32 ->
   (ByteString -> m ()) ->
   (Request ByteString -> m ())
 makeRequestSender limit publish x =

--- a/src/Network/GRPC/MQTT/Message/Response.hs
+++ b/src/Network/GRPC/MQTT/Message/Response.hs
@@ -240,7 +240,7 @@ makeResponseSender ::
   MonadUnliftIO m =>
   MQTTClient ->
   Topic ->
-  Int ->
+  Word32 ->
   WireEncodeOptions ->
   RemoteResult s ->
   m ()
@@ -256,7 +256,7 @@ makeErrorResponseSender ::
   MonadUnliftIO m =>
   MQTTClient ->
   Topic ->
-  Int ->
+  Word32 ->
   WireEncodeOptions ->
   RemoteError ->
   m ()

--- a/src/Network/GRPC/MQTT/Message/Stream.hs
+++ b/src/Network/GRPC/MQTT/Message/Stream.hs
@@ -164,7 +164,7 @@ runStreamChunkRead channel options = do
 makeStreamBatchSender ::
   forall io m.
   (MonadIO io, MonadUnliftIO m) =>
-  Int ->
+  Word32 ->
   WireEncodeOptions ->
   (ByteString -> m ()) ->
   io (ByteString -> m (), m ())
@@ -208,7 +208,7 @@ makeStreamBatchSender limit options publish
 
 makeStreamChunkSender ::
   MonadUnliftIO m =>
-  Int ->
+  Word32 ->
   WireEncodeOptions ->
   Vector ByteString ->
   (ByteString -> m ()) ->
@@ -220,7 +220,7 @@ makeStreamChunkSender limit options chunks publish = do
 
 makeStreamFinalSender ::
   MonadUnliftIO m =>
-  Int ->
+  Word32 ->
   WireEncodeOptions ->
   (ByteString -> m ()) ->
   m ()

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -317,7 +317,7 @@ data SessionConfig = SessionConfig
   , cfgSessions :: TMap Topic SessionHandle
   , cfgLogger :: Logger
   , cfgTopics :: {-# UNPACK #-} !SessionTopic
-  , cfgMsgSize :: {-# UNPACK #-} !Int
+  , cfgMsgSize :: {-# UNPACK #-} !Word32
   , cfgMethods :: MethodMap
   }
   deriving (Generic)

--- a/test/Test/Network/GRPC/MQTT/Message/Packet.hs
+++ b/test/Test/Network/GRPC/MQTT/Message/Packet.hs
@@ -8,7 +8,8 @@ where
 
 --------------------------------------------------------------------------------
 
-import Hedgehog (Property, PropertyT, forAll, property, tripping, (===))
+--------------------------------------------------------------------------------
+import Hedgehog (Property, forAll, property, tripping, withTests, (===))
 import Hedgehog qualified
 
 import Test.Tasty (TestTree, testGroup)
@@ -22,7 +23,12 @@ import Test.Network.GRPC.MQTT.Message.Gen qualified as Message.Gen
 
 import Control.Concurrent.Async (concurrently)
 
-import Control.Concurrent.STM.TQueue (TQueue, writeTQueue, newTQueueIO)
+import Control.Concurrent.STM.TQueue
+  ( TQueue,
+    flushTQueue,
+    newTQueueIO,
+    writeTQueue,
+  )
 
 import Relude hiding (reader)
 
@@ -30,6 +36,7 @@ import Relude hiding (reader)
 
 import Network.GRPC.MQTT.Message.Packet qualified as Packet
 
+import Data.ByteString qualified as ByteString
 import Proto3.Wire.Decode (ParseError)
 
 --------------------------------------------------------------------------------
@@ -43,53 +50,24 @@ tests :: TestTree
 tests =
   testGroup
     "Network.GRPC.MQTT.Message.Packet"
-    [ testTreePacketWire
-    , testTreePacketHandle
+    [ testProperty "Packet.Wire" propPacketWire
+    , testProperty "Packet.Handle" propPacketHandle
+    , testProperty "Packet.MaxSize" propPacketMaxSize
     ]
 
--- Packet.Wire -----------------------------------------------------------------
-
-testTreePacketWire :: TestTree
-testTreePacketWire =
-  testGroup
-    "Packet.Wire"
-    [ testProperty "Packet.Wire.Client" propPacketWireClient
-    , testProperty "Packet.Wire.Remote" propPacketWireRemote
-    ]
-
-propPacketWireClient :: Property
-propPacketWireClient = property do
+propPacketWire :: Property
+propPacketWire = property do
   packet <- forAll Message.Gen.packet
   tripping @_ @(Either ParseError)
     packet
     Packet.wireWrapPacket'
     Packet.wireUnwrapPacket
 
-propPacketWireRemote :: Property
-propPacketWireRemote = property do
-  packet <- forAll Message.Gen.packet
-  tripping @_ @(Either ParseError)
-    packet
-    Packet.wireWrapPacket'
-    Packet.wireUnwrapPacket
-
--- Packet.Handle ---------------------------------------------------------------
-
-testTreePacketHandle :: TestTree
-testTreePacketHandle =
-  testGroup
-    "Packet.Handle"
-    [ testProperty "Packet.Handle.ClientToRemote" propHandleClientToRemote
-    ]
-
-propHandleClientToRemote :: Property
-propHandleClientToRemote = property mockHandlePacket 
-
-mockHandlePacket :: PropertyT IO ()
-mockHandlePacket = do
+propPacketHandle :: Property
+propPacketHandle = property do
   message <- forAll Message.Gen.packetBytes
-  queue <- Hedgehog.evalIO newTQueueIO
   maxsize <- forAll (Message.Gen.packetSplitLength message)
+  queue <- Hedgehog.evalIO newTQueueIO
 
   let reader :: ExceptT ParseError IO ByteString
       reader = Packet.makePacketReader queue
@@ -104,3 +82,21 @@ mockHandlePacket = do
 
 mockPublish :: TQueue ByteString -> ByteString -> IO ()
 mockPublish queue message = atomically (writeTQueue queue message)
+
+propPacketMaxSize :: Property
+propPacketMaxSize = property do
+  message <- forAll Message.Gen.packetBytes
+  maxsize <- forAll (Message.Gen.packetSplitLength message)
+  queue <- Hedgehog.evalIO newTQueueIO
+
+  let sender :: ByteString -> IO ()
+      sender = Packet.makePacketSender maxsize (atomically . writeTQueue queue)
+
+  packets <- Hedgehog.evalIO do
+    sender message
+    atomically (flushTQueue queue)
+
+  for_ packets \packet ->
+    let size :: Word32
+        size = fromIntegral (ByteString.length packet)
+     in Hedgehog.assert (size <= maxsize)


### PR DESCRIPTION
This PR fixes a bug in how packets are split that would cause the size of serialized packets to be exceed the maximum packet size by a few bytes.

### Bug

The problem occurred when serializing packets with a payload equal to the maximum packet size. The packet fields `position` and `npackets` were not accounted for when splitting a `ByteString` into packets. This mean't that a packet with a payload length equal to the max packet size would exceed the maximum packet size after the bytes from `position` and `npacket` fields were included in the serialized message.

The bug can be observed by running the "LongBytes" test, which has a maximum packet size of 128, but was publishing messages with a length of 128,008 bytes.

```
0000000000: Sending PUBLISH to Test.Client (d0, q1, r0, m310, 'testMachine/testclient/grpc/session/jHZ2qX6RAn37-G-1HBgQPJgc', ... (128008 bytes))
```

The additional 8 bytes here are the serialized varint wire type, field numbers, and `Int` values for the fields `position` and `npackets`. 

### Fix 

* The type of `position` and `npackets` field was change from `Int` to `Word32`. This enables `Packet` to serialize the `position` and `npackets` fields in as fixed-length unsigned integers via the `sfixed32` encoding and decoding functions. This fixes overhead introduced by `Packet` to 14 bytes that can be accounted for when the packet's payload is being split.
* Serialization overhead introduced by `position` and `npacket` was deducted from the max packet payload size in `makePacketSender`.
* A minimum packet size was set at 16 bytes. Serializing packets with a packet size fewer than 16 bytes is not possible without exceeding the maximum packet size. 
* Tests were added to ensure the maximum packet size is never exceeded.