### PR TITLE
Fix `ProtoOptions` wire serialization

### DIFF
--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.3.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "05s3p5xidfdqh3vghday62pscl968vx9r3xmqhs037a8ark3gr6h";
-    rev = "112777023f475ddd752c954056e679fbca0baa44";
+    sha256 = "sha256-/+mNNpOGkOXzh3SX6lV2riXknvLsSdIAIbUWy5kKlmE=";
+    rev = "8bb4f062be4e92fca4bf4d5980db56547b4c116b";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.3.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "05s3p5xidfdqh3vghday62pscl968vx9r3xmqhs037a8ark3gr6h";
-    rev = "112777023f475ddd752c954056e679fbca0baa44";
+    sha256 = "sha256-/+mNNpOGkOXzh3SX6lV2riXknvLsSdIAIbUWy5kKlmE=";
+    rev = "8bb4f062be4e92fca4bf4d5980db56547b4c116b";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/src/Network/GRPC/HighLevel/Orphans.hs
+++ b/src/Network/GRPC/HighLevel/Orphans.hs
@@ -5,9 +5,6 @@ module Network.GRPC.HighLevel.Orphans () where
 
 ---------------------------------------------------------------------------------
 
-import Data.Data (Data)
-
-import Network.GRPC.HighLevel (MetadataMap (MetadataMap))
 import Network.GRPC.HighLevel.Client (ClientResult (..))
 
 import Relude
@@ -15,6 +12,3 @@ import Relude
 ---------------------------------------------------------------------------------
 
 deriving stock instance Functor (ClientResult s)
-
-deriving stock instance Data MetadataMap
-deriving newtype instance Ord MetadataMap

--- a/src/Network/GRPC/MQTT/Option/Batched.hs
+++ b/src/Network/GRPC/MQTT/Option/Batched.hs
@@ -76,7 +76,7 @@ import Proto3.Suite.DotProto qualified as DotProto
 
 import Relude
 
-import Proto3.Suite.Class (HasDefault, Primitive, def)
+import Proto3.Suite.Class (HasDefault, Primitive, Message, def)
 
 import Proto3.Wire.Class (ProtoEnum)
 
@@ -93,9 +93,9 @@ import Network.GRPC.MQTT.Proto (ProtoDatum)
 --
 -- @since 0.1.0.0
 newtype Batched = Batch {getBatched :: Bool}
-  deriving newtype (Eq, Ord, Primitive, ProtoDatum)
-  deriving stock (Data, Generic, Lift, Typeable)
-  deriving anyclass (ProtoEnum)
+  deriving newtype (Primitive, ProtoDatum)
+  deriving stock (Data, Eq, Ord, Generic, Lift, Typeable)
+  deriving anyclass (Message, ProtoEnum)
 
 -- | Pattern synonym for enabled batching.
 --

--- a/src/Network/GRPC/MQTT/Option/CLevel.hs
+++ b/src/Network/GRPC/MQTT/Option/CLevel.hs
@@ -55,6 +55,7 @@ import Proto3.Suite.Class
   ( Finite (enumerate),
     Named (nameOf),
     Primitive (decodePrimitive, encodePrimitive, primType),
+    Message,
   )
 import Proto3.Suite.DotProto (DotProtoPrimType, DotProtoValue, Path)
 import Proto3.Suite.DotProto qualified as DotProto
@@ -89,9 +90,9 @@ import Proto3.Wire.Decode.Extra qualified as Decode
 -- 'Int' value is known to always be between @1@ and @22@ (inclusively).
 --
 -- @since 0.1.0.0
-newtype CLevel = CLevel {getCLevel :: Int}
-  deriving newtype (Eq, Ord, Typeable)
-  deriving stock (Data, Generic, Lift)
+newtype CLevel = CLevel {getCLevel :: Int32}
+  deriving stock (Data, Eq, Generic, Lift, Ord)
+  deriving anyclass (Message)
 
 -- |
 -- @'minBound' == 'CLevel' 1@
@@ -101,7 +102,7 @@ newtype CLevel = CLevel {getCLevel :: Int}
 -- @since 0.1.0.0
 instance Bounded CLevel where
   minBound = CLevel 1
-  maxBound = CLevel Zstd.maxCLevel
+  maxBound = CLevel (fromIntegral @Int @Int32 Zstd.maxCLevel)
 
 -- | @'show' ('CLevel' 10) == "CLEVEL_10"@
 --
@@ -120,10 +121,10 @@ instance ProtoEnum CLevel where
 
 -- | @since 0.1.0.0
 instance Finite CLevel where
-  enumerate _ = map (mkenum . CLevel) [1 .. Zstd.maxCLevel]
+  enumerate _ = map makeEnum [0 .. 21]
     where
-      mkenum :: IsString s => CLevel -> (s, Int32)
-      mkenum x = (show x, fromCLevel x)
+      makeEnum :: IsString s => Int32 -> (s, Int32)
+      makeEnum x = (show (CLevel (1 + x)), x)
 
 -- | @'nameOf' ('proxy#' :: 'Proxy#' 'CLevel') == \"CLevel\"@
 --

--- a/src/Network/GRPC/MQTT/Option/CLevel.hs
+++ b/src/Network/GRPC/MQTT/Option/CLevel.hs
@@ -121,10 +121,10 @@ instance ProtoEnum CLevel where
 
 -- | @since 0.1.0.0
 instance Finite CLevel where
-  enumerate _ = map makeEnum [0 .. 21]
+  enumerate _ = map makeEnum [1 .. 22]
     where
       makeEnum :: IsString s => Int32 -> (s, Int32)
-      makeEnum x = (show (CLevel (1 + x)), x)
+      makeEnum x = (show (CLevel x), x)
 
 -- | @'nameOf' ('proxy#' :: 'Proxy#' 'CLevel') == \"CLevel\"@
 --

--- a/test/Test/Network/GRPC/MQTT/Option/Gen.hs
+++ b/test/Test/Network/GRPC/MQTT/Option/Gen.hs
@@ -40,4 +40,4 @@ batched = Batched.Batch <$> Gen.bool
 
 -- | TODO
 clevel :: MonadGen m => m CLevel
-clevel = CLevel.CLevel <$> Gen.int (Range.constant 1 22)
+clevel = CLevel.CLevel <$> Gen.int32 (Range.constant 1 22)

--- a/test/Test/Service.hs
+++ b/test/Test/Service.hs
@@ -156,22 +156,20 @@ testCallLongBytes = do
   withTestService \_ -> do
     withGRPCClient configGRPC \grpcClient -> do
       methods <- testServiceRemoteClientMethodMap grpcClient
-      results <- Async.withAsync (runRemoteClient logger remoteConfig baseTopic methods) \_ -> do
-        withMQTTGRPCClient logger clientConfig \client ->
-          Async.replicateConcurrently 8 do
+      result <- Async.withAsync (runRemoteClient logger remoteConfig baseTopic methods) \_ -> do
+        withMQTTGRPCClient logger clientConfig \client -> do
             -- For uniquely identifying requests to the server.
             uuid <- UUID.nextRandom
 
             -- NB: 2022-08-02 we discovered a bug with concurrent client
             -- requests that send responses which, when sent back by the
             -- server trigger a GRPCIOTimeout error in some of the clients.
-            let msg = Message.OneInt 8
+            let msg = Message.OneInt 64
             let rqt = GRPC.MQTT.MQTTNormalRequest msg 300 (GRPC.Client.MetadataMap (Map.fromList [("rqt-uuid", [UUID.toASCIIBytes uuid])]))
 
             testServicecallLongBytes (testServiceMqttClient client baseTopic) rqt
 
-      liftIO do
-        forM_ results $ \case
+      liftIO case result of
           GRPCResult (ClientNormalResponse (Message.BytesResponse x) _ms0 _ms1 _stat _details) -> do
             print (ByteString.length x)
           GRPCResult (ClientErrorResponse err) -> do

--- a/test/Test/Service.hs
+++ b/test/Test/Service.hs
@@ -236,7 +236,7 @@ testServerStreamCall = do
   buffer <- liftIO $ newIORef Seq.empty
 
   let msg = Message.StreamRequest "Alice" 100
-  let rqt = MQTTReaderRequest msg 30 mempty (serverStreamHandler buffer)
+  let rqt = MQTTReaderRequest msg 100 mempty (serverStreamHandler buffer)
   rsp <- makeMethodCall testServiceServerStreamCall rqt
 
   let expected :: Seq StreamReply
@@ -248,7 +248,7 @@ testBatchServerStreamCall = do
   buffer <- liftIO $ newIORef Seq.empty
 
   let msg = Message.StreamRequest "Alice" 100
-  let rqt = MQTTReaderRequest msg 30 mempty (serverStreamHandler buffer)
+  let rqt = MQTTReaderRequest msg 300 mempty (serverStreamHandler buffer)
   rsp <- makeMethodCall testServiceBatchServerStreamCall rqt
 
   let expected :: Seq StreamReply


### PR DESCRIPTION
This PR removes slight differences between the encoding and decoding side of `ProtoOptions` wire serialization functions. Specifically, using [`packedVarints`](https://github.com/awakesecurity/grpc-mqtt/blob/4dbf3df65be462e31a125a4993fda51ce911b728/src/Network/GRPC/MQTT/Option.hs#L217) to parse serialized `ProtoOption` messages while [`packedVarintsV`](https://github.com/awakesecurity/grpc-mqtt/blob/4dbf3df65be462e31a125a4993fda51ce911b728/src/Network/GRPC/MQTT/Option.hs#L196) was used to serialize the original messages.

This work builds off of #48.