### PR TITLE
Perform packet serialization in place.

### DIFF
--- a/nix/packages/proto3-wire.nix
+++ b/nix/packages/proto3-wire.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "1.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-wire";
-    sha256 = "059na8az87cl6h0h9q5q6jnkbnw38rgywa1x1rrvihnh99bj7g2v";
-    rev = "baf23455bda0c5a316711f7d91aa86f43c934e7f";
+    sha256 = "1kpz9ndihn9905c20g106lghx7i7kl8lc4fqhh8cybvgrxl24yrg";
+    rev = "5a946d2a5eeecd0d17265181503669d40d61629e";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [

--- a/nix/packages/proto3-wire.nix
+++ b/nix/packages/proto3-wire.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "1.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-wire";
-    sha256 = "1pr078k7j5yvsixh7g76bfb3w5a5nxsjl9lgvc5ji4nm0ngx5i61";
-    rev = "ae24c00c83cbce29750005b1fa6506c1e62e4822";
+    sha256 = "059na8az87cl6h0h9q5q6jnkbnw38rgywa1x1rrvihnh99bj7g2v";
+    rev = "baf23455bda0c5a316711f7d91aa86f43c934e7f";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [

--- a/src/Network/GRPC/MQTT/Message/Packet.hs
+++ b/src/Network/GRPC/MQTT/Message/Packet.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UnboxedTuples #-}
 
 -- | This module exports definitions for the 'Packet' message type.
 --
@@ -38,6 +39,10 @@ module Network.GRPC.MQTT.Message.Packet
     mergePacketSet,
     insertPacketSet,
     lengthPacketSet,
+
+    -- * Unsafe
+    encodeBufferOffPacket,
+    withEncodeBuffer,
   )
 where
 
@@ -49,23 +54,47 @@ import Control.Concurrent.TMap as TMap
 
 import Control.Concurrent.STM.TQueue (TQueue, readTQueue)
 
+import Control.Exception (assert)
+
 import Control.Monad.Except (MonadError, liftEither)
 
 import Data.ByteString qualified as ByteString
 import Data.ByteString.Builder qualified as ByteString (Builder)
 import Data.ByteString.Builder qualified as ByteString.Builder
+import Data.ByteString.Unsafe qualified as ByteString.Unsafe
 import Data.Data (Data)
+import Data.Primitive.ByteArray
+  ( MutableByteArray,
+    getSizeofMutableByteArray,
+    mutableByteArrayContents,
+    newAlignedPinnedByteArray,
+  )
+
+import Foreign.Ptr (Ptr)
+import Foreign.StablePtr (StablePtr, freeStablePtr, newStablePtr)
+
+import GHC.Exts (RealWorld)
+import GHC.Ptr (castPtr, nullPtr, plusPtr)
 
 import Proto3.Wire.Decode (ParseError, Parser, RawMessage)
 import Proto3.Wire.Decode qualified as Decode
 import Proto3.Wire.Encode (MessageBuilder)
 import Proto3.Wire.Encode qualified as Encode
+import Proto3.Wire.Reverse.Internal
+  ( BuildRState (..),
+    fromBuildR,
+    metaDataAlign,
+    metaDataSize,
+    readTotal,
+    writeSpace,
+    writeState,
+  )
 
 import Relude
 
 import Text.Printf qualified as Text
 
-import UnliftIO (MonadUnliftIO, throwIO)
+import UnliftIO (MonadUnliftIO, bracket, throwIO)
 import UnliftIO.Async (replicateConcurrently_)
 
 -- Packet ----------------------------------------------------------------------
@@ -199,7 +228,7 @@ minPacketSize = 16
 --
 -- @since 1.0.0
 maxPacketSize :: Word32
-maxPacketSize = 256 * 2 ^ (20 :: Int) - 128 * 2 ^ (10 :: Int) 
+maxPacketSize = 256 * 2 ^ (20 :: Int) - 128 * 2 ^ (10 :: Int)
 
 -- | Construct a packetized message sender given the maximum size for each
 -- packet payload (in bytes), the wire serialization options, and a MQTT publish
@@ -208,7 +237,7 @@ maxPacketSize = 256 * 2 ^ (20 :: Int) - 128 * 2 ^ (10 :: Int)
 -- @since 0.1.0.0
 makePacketSender ::
   MonadUnliftIO m =>
-  -- | The maximum packet payload size. This must be a 'Word32' value greater 
+  -- | The maximum packet payload size. This must be a 'Word32' value greater
   -- than or equal to 'minPacketSize' and less than 'maxPacketSize'. Otherwise,
   -- a 'PacketSizeError' exception will be thrown.
   Word32 ->
@@ -221,7 +250,7 @@ makePacketSender limit publish message = do
 
   if fromIntegral (ByteString.length message) <= maxPayloadSize
     then do
-      -- Perform a single publish on the current thread in case that the 
+      -- Perform a single publish on the current thread in case that the
       -- @message@ length is less than the maximum payload size.
       let packet = Packet message 0 1
       publish (wireWrapPacket' packet)
@@ -229,13 +258,18 @@ makePacketSender limit publish message = do
       caps <- liftIO getNumCapabilities
       jobs <- newTVarIO 0
 
-      replicateConcurrently_ caps $ fix \next ->
-        atomically (takeJobId jobs) >>= \case
-          Nothing -> pure ()
-          Just jobid -> do
-            let packet = makePacket jobid
-            publish (wireWrapPacket' packet)
-            next
+      replicateConcurrently_ caps do
+        let bufferSize :: Int
+            bufferSize = fromIntegral limit + metaDataSize
+         in withEncodeBuffer bufferSize \ptr -> do
+              fix \next -> do
+                atomically (takeJobId jobs) >>= \case
+                  Nothing -> pure ()
+                  Just jobid -> do
+                    let packet = makePacket jobid
+                    serialized <- encodeBufferOffPacket ptr bufferSize packet
+                    publish serialized
+                    next
   where
     maxPayloadSize :: Word32
     maxPayloadSize = max (limit - minPacketSize) 1
@@ -372,3 +406,85 @@ isMissingPackets = do
       Just ct -> do
         len <- lengthPacketSet pxs
         pure (fromIntegral len - 1 < ct)
+
+-- Unsafe ----------------------------------------------------------------------
+
+fromPacketBuildR ::
+  MonadIO m =>
+  Ptr Word8 ->
+  Int ->
+  Packet ByteString ->
+  m (Ptr Word8, Int)
+fromPacketBuildR buffer unused packet = do
+  let build = Encode.reverseMessageBuilder (wireBuildPacket packet)
+  liftIO (fromBuildR build buffer unused)
+
+encodeBufferOffPacket ::
+  MonadIO m =>
+  Ptr Word8 ->
+  Int ->
+  Packet ByteString ->
+  m ByteString
+encodeBufferOffPacket ptr unused packet = do
+  (ptr', unused') <- fromPacketBuildR ptr unused packet
+  size <- liftIO (readTotal ptr' unused')
+  liftIO (unsafePackCStringLen ptr' size)
+
+withEncodeBuffer :: MonadUnliftIO m => Int -> (Ptr Word8 -> m a) -> m a
+withEncodeBuffer packetSizeLimit k = do
+  let bufferSize = metaDataSize + packetSizeLimit
+  buf <- liftIO (newAlignedPinnedByteArray bufferSize metaDataAlign)
+  stateVar <- newIORef BuildRState{currentBuffer = buf, sealedBuffers = mempty}
+  withStablePtr stateVar \statePtr -> do
+    k =<< liftIO (resetEncodeBuffer buf statePtr)
+
+resetEncodeBuffer ::
+  MutableByteArray RealWorld ->
+  StablePtr (IORef BuildRState) ->
+  IO (Ptr Word8)
+resetEncodeBuffer buf statePtr = do
+  allocationSize <- getSizeofMutableByteArray buf
+  let !p = mutableByteArrayContents buf
+  let !v = plusPtr p allocationSize
+  let !m = plusPtr p metaDataSize
+  writeState m statePtr
+  writeSpace m (allocationSize - metaDataSize)
+  pure v
+
+-- Unsafe - Helpers ------------------------------------------------------------
+
+-- | Similar to 'bracket', @'withStablePtr' x io@ constructs a managed
+-- 'StablePtr' referring to the value @x@ and provides it to the context that
+-- executes the 'IO' action @io@.
+withStablePtr :: MonadUnliftIO m => a -> (StablePtr a -> m b) -> m b
+withStablePtr x = bracket (liftIO (newStablePtr x)) (liftIO . freeStablePtr)
+
+-- | @unsafePackCStringLen ptr len@ constructs a 'ByteString' from a 'Word8'
+-- array pointer and the length of that array in bytes.
+--
+-- * If the argument to @len@ is less than the actual size of the allocation
+--   @ptr@ refers to, then difference will be dropped from the tail of the array
+--   in a best-case scenario. In the worst-case, the bytestring's foreign ptr
+--   is reclaimed by the garbage collector while it is still alive.
+--
+-- * This function asserts that @len@ be greater than or equal to 0, otherwise
+--   an 'ErrorCall' exception (i.e. an 'error' call) will be thrown that cannot
+--   be handled in pure code
+--
+-- * This function asserts that the argument @ptr@ is not equivalent to the null
+--   pointer.
+--
+-- This function is highly unsafe. 
+unsafePackCStringLen :: Ptr Word8 -> Int -> IO ByteString
+unsafePackCStringLen ptr len =
+  -- "bytestring" recommends using 'unsafePackCStringLen' for constructing
+  -- bytestrings given the pointer to the array in memory and the size of that
+  -- array.
+  --
+  -- The pointer cast below is only necessary since 'unsafePackCStringLen'
+  -- expects a 'CChar'@pointer. This cast is only safe in this context because
+  -- 'unsafePackCStringLen' casts this back to a 'Word8' pointer in order to
+  -- construct the bytestring's foreign pointer.
+  let !ptr' = assert (ptr /= nullPtr) (castPtr ptr)
+      !len' = assert (len >= 0) len
+   in ByteString.Unsafe.unsafePackCStringLen (ptr', len')

--- a/test/Test/Core.hs
+++ b/test/Test/Core.hs
@@ -6,9 +6,8 @@ where
 
 import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
 
-import Data.ByteString.Internal (ByteString, create, memcpy)
+import Data.ByteString.Internal (create, memcpy, toForeignPtr)
 import Data.ByteString qualified as ByteString
-import Data.ByteString.Internal qualified as ByteString.Internal
 
 import Foreign.ForeignPtr (withForeignPtr)
 
@@ -16,11 +15,32 @@ import Relude
 
 --------------------------------------------------------------------------------
 
+-- | 'mockPublish' is a helper function used to simulate publishing a packet 
+-- over MQTT. This helper can be used to bridge the gap between sender and 
+-- reader pairs such as 'Network.GRPC.MQTT.Message.Request.makeRequestReader' 
+-- and 'Network.GRPC.MQTT.Message.Request.makeRequestSender' in tests without 
+-- requiring a service to be initialized first.
 mockPublish :: TQueue ByteString -> ByteString -> IO ()
 mockPublish queue message = do
-  let (ptr, _, _) = ByteString.Internal.toForeignPtr message
-  let len = ByteString.length message 
+  let !(ptr, _, _) = toForeignPtr message
+  let !len = ByteString.length message 
+
+  -- Explicitly copies the bytestring's contents into a fresh allocation.
+  -- This disconnects the bytestring content and the underlying 'ForeignPtr' 
+  -- before writing it to the recieving end's 'TQueue'. This is desirable for 
+  -- two reason:
+  --
+  -- 1. In real-world applications, the 'ByteString' obtained by the reader used 
+  --    on recieving end of a MQTT publish and the 'ByteString' provided to the 
+  --    MQTT publish function will never share the same allocation. Explicitly 
+  --    cloning the content ensures that test cases respect this property. 
+  --  
+  -- 2. The packet publishing function 'makePacketSender' operates on memory 
+  --    in-place. If the same 'ForeignPtr' is being used in 'makePacketSender' 
+  --    serialization as is being used in packet reader, then tests will hang 
+  --    indefinitely due to TMVar deadlock. 
   recv <- create len \recvPtr -> 
     withForeignPtr ptr \sendPtr ->
       memcpy recvPtr sendPtr len
+
   atomically (writeTQueue queue recv)

--- a/test/Test/Core.hs
+++ b/test/Test/Core.hs
@@ -1,0 +1,26 @@
+
+module Test.Core 
+  ( mockPublish
+  )
+where 
+
+import Control.Concurrent.STM.TQueue (TQueue, writeTQueue)
+
+import Data.ByteString.Internal (ByteString, create, memcpy)
+import Data.ByteString qualified as ByteString
+import Data.ByteString.Internal qualified as ByteString.Internal
+
+import Foreign.ForeignPtr (withForeignPtr)
+
+import Relude
+
+--------------------------------------------------------------------------------
+
+mockPublish :: TQueue ByteString -> ByteString -> IO ()
+mockPublish queue message = do
+  let (ptr, _, _) = ByteString.Internal.toForeignPtr message
+  let len = ByteString.length message 
+  recv <- create len \recvPtr -> 
+    withForeignPtr ptr \sendPtr ->
+      memcpy recvPtr sendPtr len
+  atomically (writeTQueue queue recv)


### PR DESCRIPTION
This PR changes `Network.MQTT.GRPC.Message.Packet` so that the same `proto3-wire` serialization buffer is reused after each packet is publish. This significantly reduces the maximum heap residency accumulated in the process of splitting a larger message into packets that are individually published.

Related: 

- Builds off previous changes #43, #37, and #42 improving performance and memory usage for packet publishes.
- Depends on changes to [`proto3-wire`](https://github.com/awakesecurity/proto3-wire/pull/89) exposing internal functions that were needed.