### PR TITLE
Upgrade pinned rev for gRPC-haskell(-core)

### DIFF
--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.3.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "sha256-/+mNNpOGkOXzh3SX6lV2riXknvLsSdIAIbUWy5kKlmE=";
-    rev = "8bb4f062be4e92fca4bf4d5980db56547b4c116b";
+    sha256 = "0lvv0jyaxrwg6zw8ydabna6rrq2qns1phl5v1z6kmi2pkgyr37rd";
+    rev = "f27da0205a774c84dde27b2d0ea306eca25cb710";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.3.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "sha256-/+mNNpOGkOXzh3SX6lV2riXknvLsSdIAIbUWy5kKlmE=";
-    rev = "8bb4f062be4e92fca4bf4d5980db56547b4c116b";
+    sha256 = "0lvv0jyaxrwg6zw8ydabna6rrq2qns1phl5v1z6kmi2pkgyr37rd";
+    rev = "f27da0205a774c84dde27b2d0ea306eca25cb710";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
Upgrade pinned revision for the gRPC-haskell and gRPC-haskell-core packages. The new revision includes the changes made by [`gRPC-haskell/142`](https://github.com/awakesecurity/gRPC-haskell/pull/142). These changes add helper functions `startGRPC` and `stopGRPC` that can be used to clean up test suite in `grpc-mqtt`.