### PR TITLE
Add Haddock module descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cabal.project.local
 result
 .hpc
 test-files/mqtt-broker.pid
+.envrc

--- a/src/Control/Concurrent/TMap.hs
+++ b/src/Control/Concurrent/TMap.hs
@@ -1,8 +1,15 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
--- | Definitions for the 'TMap' container.
+-- |
+-- Module      :  Control.Concurrent.TMap
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Definitions for the 'TMap' container.
+--
+-- @since 1.0.0
 module Control.Concurrent.TMap
   ( -- * TMap
     TMap (TMap, getTMap),
@@ -47,7 +54,7 @@ import Relude hiding (empty, length)
 
 -- | STM-specialized non-blocking 'Map' container.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype TMap k v = TMap
   {getTMap :: IORef (Map k (TVar v))}
 
@@ -55,13 +62,13 @@ newtype TMap k v = TMap
 
 -- | Constructs an empty 'TMap'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 empty :: STM (TMap k v)
 empty = unsafeIOToSTM emptyIO
 
 -- | Like 'empty', constructs the empty 'TMap' in 'IO'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 emptyIO :: IO (TMap k v)
 emptyIO = fmap TMap (newIORef Map.empty)
 
@@ -70,7 +77,7 @@ emptyIO = fmap TMap (newIORef Map.empty)
 -- | Converts a 'TMap' to a list of key-value pairs sorted in ascending key
 -- order.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toAscList :: TMap k v -> STM [(k, v)]
 toAscList (TMap ref) = do
   kvs0 <- unsafeIOToSTM (readIORef ref)
@@ -82,7 +89,7 @@ toAscList (TMap ref) = do
 -- | Inserts a new key-value pair into the 'TMap'. If the 'TMap' already contains
 -- then given key, the associated value will be replaced.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insert :: Ord k => k -> v -> TMap k v -> STM ()
 insert k x (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -99,7 +106,7 @@ insert k x (TMap ref) = do
 -- | Removes the value associated to the key. If the key is not a member 'TMap',
 -- no change is made.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 delete :: Ord k => k -> TMap k v -> STM ()
 delete k (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -113,7 +120,7 @@ delete k (TMap ref) = do
 
 -- | Return the number of elements in the 'TMap'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 length :: TMap k v -> STM Int
 length (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -121,7 +128,7 @@ length (TMap ref) = do
 
 -- | Is the the key an element of the 'TMap'?
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 member :: Ord k => k -> TMap k v -> STM Bool
 member k (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -129,7 +136,7 @@ member k (TMap ref) = do
 
 -- | Returns the value associated to the given key, if one exists.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 lookup :: Ord k => k -> TMap k v -> STM (Maybe v)
 lookup k (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -141,7 +148,7 @@ lookup k (TMap ref) = do
 
 -- | Right-associative fold indexed by the map keys.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 ifoldr :: forall k v m. (k -> v -> m -> STM m) -> m -> TMap k v -> STM m
 ifoldr cons nil (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)
@@ -158,7 +165,7 @@ ifoldr cons nil (TMap ref) = do
 --
 -- prop> elems kvs ~ map snd (toAscList kvs)
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 elems :: TMap k v -> STM [v]
 elems (TMap ref) = do
   kvs <- unsafeIOToSTM (readIORef ref)

--- a/src/Control/Concurrent/TMap.hs
+++ b/src/Control/Concurrent/TMap.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Control.Concurrent.TMap
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/HighLevel/Extra.hs
+++ b/src/Network/GRPC/HighLevel/Extra.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.HighLevel.Extra
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/HighLevel/Extra.hs
+++ b/src/Network/GRPC/HighLevel/Extra.hs
@@ -1,10 +1,17 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeApplications #-}
 
--- | Definitions extending to grpc-haskell.
+-- |
+-- Module      :  Network.GRPC.HighLevel.Extra
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Definitions extending to grpc-haskell.
+--
+-- @since 1.0.0
 module Network.GRPC.HighLevel.Extra
   ( -- * Wire Encoding
     wireEncodeMetadataMap,

--- a/src/Network/GRPC/HighLevel/Orphans.hs
+++ b/src/Network/GRPC/HighLevel/Orphans.hs
@@ -1,6 +1,14 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+-- |
+-- Module      :  Network.GRPC.HighLevel.Orphans
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
 module Network.GRPC.HighLevel.Orphans () where
 
 ---------------------------------------------------------------------------------

--- a/src/Network/GRPC/HighLevel/Orphans.hs
+++ b/src/Network/GRPC/HighLevel/Orphans.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.HighLevel.Orphans
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT.hs
+++ b/src/Network/GRPC/MQTT.hs
@@ -3,9 +3,15 @@
 -- module is only managing re-exports.
 {-# OPTIONS_GHC -Wno-missing-import-lists #-}
 
--- | Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
+-- |
+-- Module      :  Network.GRPC.MQTT
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT
   ( -- * 'net-mqtt' Re-exports
     module Network.MQTT.Client,

--- a/src/Network/GRPC/MQTT.hs
+++ b/src/Network/GRPC/MQTT.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -1,15 +1,19 @@
--- Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
--- | The client API for making gRPC requests over MQTT.
+-- |
+-- Module      :  Network.GRPC.MQTT.Client
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- The client API for making gRPC requests over MQTT.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Client
   ( MQTTGRPCClient (..),
     mqttRequest,
@@ -133,7 +137,7 @@ import Proto.Mqtt (RemoteError)
 
 -- | Client for making gRPC calls over MQTT
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data MQTTGRPCClient = MQTTGRPCClient
   { -- | The MQTT client
     mqttClient :: MQTTClient
@@ -153,7 +157,7 @@ data MQTTGRPCClient = MQTTGRPCClient
 -- `MQTTGRPCClient' to the supplied function, closing the connection for you when
 -- the function finishes.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 withMQTTGRPCClient :: Logger -> MQTTGRPCConfig -> (MQTTGRPCClient -> IO a) -> IO a
 withMQTTGRPCClient logger cfg =
   bracket
@@ -163,7 +167,7 @@ withMQTTGRPCClient logger cfg =
 -- | Send a gRPC request over MQTT using the provided client This function makes
 -- synchronous requests.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 mqttRequest ::
   forall request response streamtype.
   (Message request, Message response, HasDefault request) =>
@@ -306,14 +310,14 @@ mqttRequest MQTTGRPCClient{..} baseTopic nmMethod options request = do
 -- | Helper function to run an 'ExceptT RemoteError' action and convert any failure
 -- to an 'MQTTResult'
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 exceptToResult :: Functor f => ExceptT RemoteError f (MQTTResult s rsp) -> f (MQTTResult s rsp)
 exceptToResult = fmap (either fromRemoteError id) . runExceptT
 
 -- | Manages the control signals (Heartbeat and Terminate) asynchronously while
 -- the provided action performs a request
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 withControlSignals :: (AuxControl -> IO ()) -> IO a -> IO a
 withControlSignals publishControlMsg =
   withMQTTHeartbeat . sendTerminateOnException
@@ -331,7 +335,7 @@ withControlSignals publishControlMsg =
 -- | Connects to the MQTT broker and creates a 'MQTTGRPCClient'
 -- NB: Overwrites the '_msgCB' field in the 'MQTTConfig'
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 connectMQTTGRPC :: MonadIO io => Logger -> MQTTGRPCConfig -> io MQTTGRPCClient
 connectMQTTGRPC logger cfg = do
   queues <- newIORef (Map.empty @Topic @(TQueue ByteString))
@@ -363,7 +367,7 @@ disconnectMQTTGRPC client = liftIO (normalDisconnect (mqttClient client))
 --
 -- @'GRPCResult' ('ClientErrorResponse' ('ClientIOError' 'GRPCIOTimeout'))@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 timeoutGRPC ::
   MonadUnliftIO m =>
   TimeoutSeconds ->
@@ -379,7 +383,7 @@ timeoutGRPC timelimit'secs action = do
 -- | A variant of 'System.timeout' that accepts the timeout period in unit
 -- seconds (as opposed to microseconds).
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 timeout'secs :: MonadUnliftIO m => TimeoutSeconds -> m a -> m (Maybe a)
 timeout'secs period'secs action =
   -- @System.timeout@ expects the timeout period given to be in unit
@@ -399,7 +403,7 @@ timeout'secs period'secs action =
 -- | 'ClientTopicError' captures all exceptions that can be raised when
 -- constructing MQTT topics required by a client.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ClientTopicError
   = -- | Exception that is raised when the client generates a nonce that does
     -- not form a valid MQTT topic (this should be impossible).
@@ -409,10 +413,10 @@ data ClientTopicError
     BadRPCMethodTopicError Text
   deriving stock (Eq, Ord, Typeable)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Exception ClientTopicError
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Show ClientTopicError where
   show e = case e of
     BadSessionIdTopicError x -> formatS ("session ID " ++ show x)
@@ -432,7 +436,7 @@ instance Show ClientTopicError where
 -- >>> makeSessionIdTopic =<< Crypto.Nonce.new
 -- Topic {unTopic = "fA6L7xKY6_-qa7k3g3J7DZ-e"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeSessionIdTopic :: Nonce.Generator -> IO Topic
 makeSessionIdTopic gen = do
   uuid <- Nonce.nonce128urlT gen
@@ -458,7 +462,7 @@ makeSessionIdTopic gen = do
 -- >>> makeMethodRequestTopic "..." "..." "/bad/#/topic"
 -- *** Exception: Network.GRPC.MQTT.Client.ClientTopicError: gRPC method name"/bad/#/topic" forms invalid topic
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeMethodRequestTopic :: Topic -> Topic -> MethodName -> IO Topic
 makeMethodRequestTopic baseTopic sid (MethodName nm) =
   -- Some MQTT implementations (for e.g. RabbitMQ) can't handle dots

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Client
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Compress.hs
+++ b/src/Network/GRPC/MQTT/Compress.hs
@@ -1,7 +1,15 @@
--- | This module defines a type-safe wrappers over for the zstandard compression
+-- |
+-- Module      :  Network.GRPC.MQTT.Compress
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module defines a type-safe wrappers over for the zstandard compression
 -- functions.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Compress
   ( -- * Compression
     compress,
@@ -44,7 +52,7 @@ import Proto.Mqtt qualified as Proto
 
 -- | Compress the 'ByteString' as a single zstandard frame.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 compress :: CLevel -> ByteString -> ByteString
 compress level bytes
   | ByteString.null bytes = bytes
@@ -55,18 +63,18 @@ compress level bytes
 -- | 'ZstdError' represent the errors that can be produced during decompression.
 -- It is a generic zstandard error string emitted from the zstandard FFI.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype ZstdError = ZstdError {getZstdError :: String}
   deriving stock (Data, Eq, Ord, Show, Typeable)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Exception ZstdError where
   displayException (ZstdError err) =
     Show.showString "zstd decompression error: " err
 
 -- | Convert a 'ZstdError' to a 'RemoteError'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toRemoteError :: ZstdError -> RemoteError
 toRemoteError err =
   let encoded :: Enumerated RError
@@ -83,7 +91,7 @@ toRemoteError err =
 -- A 'ZstdError' is emitted if an error was thrown by the internal zstandard FFI
 -- call.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 decompress :: MonadError ZstdError m => ByteString -> m ByteString
 decompress bytes
   | ByteString.null bytes = pure bytes

--- a/src/Network/GRPC/MQTT/Compress.hs
+++ b/src/Network/GRPC/MQTT/Compress.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Compress
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Core
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -1,13 +1,17 @@
--- Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecordWildCards #-}
 
--- | Module defintions core components required by the library.
+-- |
+-- Module      :  Network.GRPC.MQTT.Core
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Module defintions core components required by the library.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Core
   ( MQTTGRPCConfig (..),
     connectMQTT,
@@ -76,7 +80,7 @@ import Relude
 
 -- | Superset of 'MQTTConfig'
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data MQTTGRPCConfig = MQTTGRPCConfig
   { -- | Whether or not to use TLS for the connection
     useTLS :: Bool
@@ -107,7 +111,7 @@ data MQTTGRPCConfig = MQTTGRPCConfig
 
 -- | The default 'MQTTGRPCConfig'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 defaultMGConfig :: MQTTGRPCConfig
 defaultMGConfig =
   MQTTGRPCConfig
@@ -131,13 +135,13 @@ defaultMGConfig =
 
 -- | Project 'MQTTConfig' from 'MQTTGRPCConfig'
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getMQTTConfig :: MQTTGRPCConfig -> MQTTConfig
 getMQTTConfig MQTTGRPCConfig{..} = MQTTConfig{..}
 
 -- | Connect to an MQTT broker
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 connectMQTT :: (MonadIO io) => MQTTGRPCConfig -> io MQTTClient
 connectMQTT cfg@MQTTGRPCConfig{..} = liftIO $ runMQTTConduit runClient (getMQTTConfig cfg)
   where
@@ -157,7 +161,7 @@ connectMQTT cfg@MQTTGRPCConfig{..} = liftIO $ runMQTTConduit runClient (getMQTTC
 
 -- | Period for heartbeat messages
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 heartbeatPeriodSeconds :: NominalDiffTime
 heartbeatPeriodSeconds = 10
 

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Logging
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Logging.hs
+++ b/src/Network/GRPC/MQTT/Logging.hs
@@ -1,10 +1,14 @@
--- Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
-
--- | Definitions for the 'Logger' type and logging facilities.
+-- |
+-- Module      :  Network.GRPC.MQTT.Logging
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Definitions for the 'Logger' type and logging facilities.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Logging
   ( -- * Log Verbosity
     Verbosity (Silent, Error, Warn, Info, Debug),
@@ -30,7 +34,7 @@ import Relude
 
 -- | Enumeration of logger verbosity levels.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data Verbosity
   = Silent
   | Error
@@ -44,7 +48,7 @@ data Verbosity
 -- | 'Logger' is IO action writing 'Text' to a log bundled with the minimum
 -- log verbosity level used to filter which messages are logged.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data Logger = Logger
   { runLog :: Text -> IO ()
   , verbosity :: Verbosity
@@ -52,7 +56,7 @@ data Logger = Logger
 
 -- | The silent 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 noLogging :: Logger
 noLogging = Logger (\_ -> pure ()) Silent
 
@@ -60,7 +64,7 @@ noLogging = Logger (\_ -> pure ()) Silent
 
 -- | Writes a message with a specified 'Verbosity' to the given 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logVerbosity :: (MonadIO io) => Verbosity -> Logger -> Text -> io ()
 logVerbosity v logger msg =
   when (verbosity logger >= v) do
@@ -68,24 +72,24 @@ logVerbosity v logger msg =
 
 -- | Writes an error message to the 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logErr :: (MonadIO io) => Logger -> Text -> io ()
 logErr = logVerbosity Error
 
 -- | Writes a warning to the 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logWarn :: (MonadIO io) => Logger -> Text -> io ()
 logWarn = logVerbosity Warn
 
 -- | Writes a message to the 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logInfo :: (MonadIO io) => Logger -> Text -> io ()
 logInfo = logVerbosity Info
 
 -- | Writes debug information to the 'Logger'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logDebug :: (MonadIO io) => Logger -> Text -> io ()
 logDebug = logVerbosity Debug

--- a/src/Network/GRPC/MQTT/Message.hs
+++ b/src/Network/GRPC/MQTT/Message.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message.hs
+++ b/src/Network/GRPC/MQTT/Message.hs
@@ -1,7 +1,16 @@
--- | This module exports the protobuf message types and wire serialization
+
+-- |
+-- Module      :  Network.GRPC.MQTT.Message
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module exports the protobuf message types and wire serialization
 -- functions used internally by the library.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message
   ( -- * Message Types
     Request,
@@ -57,7 +66,7 @@ import Proto.Mqtt (RemoteError)
 -- | Apply wire encoding transformations (such as compression) to a serialized
 -- 'ByteString'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 mapEncodeOptions :: WireEncodeOptions -> ByteString -> ByteString
 mapEncodeOptions options bytes =
   case Serial.encodeCLevel options of
@@ -67,7 +76,7 @@ mapEncodeOptions options bytes =
 -- | Serializes a protobuf message (an instance of 'Message') @a@ according to
 -- the 'WireEncodeOptions' provided.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toWireEncoded :: Message a => WireEncodeOptions -> a -> ByteString
 toWireEncoded options x =
   let bytes :: ByteString
@@ -79,7 +88,7 @@ toWireEncoded options x =
 -- | Apply wire decoding transformations (such as decompression) to a serialized
 -- 'ByteString'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 mapDecodeOptions ::
   MonadError WireDecodeError m =>
   WireDecodeOptions ->
@@ -95,7 +104,7 @@ mapDecodeOptions options bytes
 -- | Deserializes a wire encoded 'ByteString' into the expected protobuf message
 -- type @a@ according to the 'WireDecodeOptions' provided.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 fromWireEncoded ::
   (MonadError WireDecodeError m, Message a) =>
   WireDecodeOptions ->
@@ -113,7 +122,7 @@ fromWireEncoded options bytes = do
 -- deserializing a 'ByteString' (in wire format) according to a
 -- 'WireDecodeOptions' configuration.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data WireDecodeError
   = -- | 'DecodeWireError' is emitted when a wire parse error is encountered
     -- when parsing the 'ByteString'.
@@ -131,7 +140,7 @@ throwZstdError err = throwError (DecodeZstdError err)
 
 -- | Convert a 'WireDecodeError' into a 'RemoteError'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toRemoteError :: WireDecodeError -> RemoteError
 toRemoteError (DecodeWireError err) = parseErrorToRCE err
 toRemoteError (DecodeZstdError err) = Compress.toRemoteError err

--- a/src/Network/GRPC/MQTT/Message/AuxControl.hs
+++ b/src/Network/GRPC/MQTT/Message/AuxControl.hs
@@ -1,6 +1,14 @@
--- | This module exports definitions for the 'AuxControlMessage' message type.
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.AuxControl
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module exports definitions for the 'AuxControlMessage' message type.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.AuxControl
   ( -- * Aux Message
     AuxControlMessage

--- a/src/Network/GRPC/MQTT/Message/AuxControl.hs
+++ b/src/Network/GRPC/MQTT/Message/AuxControl.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.AuxControl
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/Packet.hs
+++ b/src/Network/GRPC/MQTT/Message/Packet.hs
@@ -1,12 +1,19 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE ViewPatterns #-}
 
--- | This module exports definitions for the 'Packet' message type.
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.Packet
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module exports definitions for the 'Packet' message type.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.Packet
   ( -- * Packet
     Packet (Packet, payload, position, npackets),
@@ -77,7 +84,7 @@ import UnliftIO.Concurrent (threadDelay)
 
 -- | 'Packet' is a MQTT packet.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data Packet msg = Packet
   { -- | 'payload' is the packets payload. For a @'Packet' 'ByteString'@, this
     -- is typically a serialized protobuf message.
@@ -97,21 +104,21 @@ data Packet msg = Packet
 
 -- | Encodes 'Packet' message in the wire binary format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireWrapPacket :: Packet ByteString -> LByteString
 wireWrapPacket = Encode.toLazyByteString . wireBuildPacket
 {-# INLINE wireWrapPacket #-}
 
 -- | Like 'wireWrapPacket', but the resulting 'ByteString' is strict.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireWrapPacket' :: Packet ByteString -> ByteString
 wireWrapPacket' = toStrict . wireWrapPacket
 {-# INLINE wireWrapPacket' #-}
 
 -- | 'MessageBuilder' combinator capable of serializing a 'Packet' message.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireBuildPacket :: Packet ByteString -> MessageBuilder
 wireBuildPacket (Packet bxs i n) =
   Encode.byteString 1 bxs
@@ -123,7 +130,7 @@ wireBuildPacket (Packet bxs i n) =
 
 -- | Parses a 'ByteString' encoding 'Packet' in the wire binary format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireUnwrapPacket ::
   MonadError ParseError m =>
   ByteString ->
@@ -133,7 +140,7 @@ wireUnwrapPacket bxs = liftEither (Decode.parse wireParsePacket bxs)
 
 -- | Parses a serialized 'Packet' message.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireParsePacket :: Parser RawMessage (Packet ByteString)
 wireParsePacket =
   Packet
@@ -148,7 +155,7 @@ wireParsePacket =
 -- produce the original unpacketized 'ByteString' reconstructed from each packet
 -- payload.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makePacketReader ::
   (MonadIO m, MonadError ParseError m) =>
   TQueue ByteString ->
@@ -210,7 +217,7 @@ maxPacketSize = 256 * 2 ^ (20 :: Int) - 128 * 2 ^ (10 :: Int)
 -- packet payload (in bytes), the wire serialization options, and a MQTT publish
 -- function.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makePacketSender ::
   forall m.
   MonadUnliftIO m =>
@@ -302,7 +309,7 @@ naturalToBounded = fromMaybe maxBound . toIntegralSized
 -- | Predicate on 'PacketInfo' testing if the 'position' is the last position for
 -- it's 'npackets'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isLastPacket :: Packet a -> Bool
 isLastPacket (Packet _ i n) = i == n - 1
 
@@ -310,20 +317,20 @@ isLastPacket (Packet _ i n) = i == n - 1
 
 -- | 'PacketSet' is a set of packets carrying a message payload type @a@.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype PacketSet a = PacketSet
   {getPacketSet :: TMap Word32 a}
 
 -- | Constructs an empty 'PacketSet' in 'IO'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 emptyPacketSetIO :: IO (PacketSet a)
 emptyPacketSetIO = fmap PacketSet TMap.emptyIO
 
 -- | Merge the payloads of each packet in a 'PacketSet' back into the original
 -- unpacketized 'ByteString'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 mergePacketSet :: PacketSet ByteString -> STM LByteString
 mergePacketSet (PacketSet pxs) = do
   parts <- TMap.elems pxs
@@ -335,7 +342,7 @@ mergePacketSet (PacketSet pxs) = do
 -- same 'position' as a previously inserted packet, then no change to the
 -- 'PacketSet' is made.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insertPacketSet :: Packet a -> PacketSet a -> STM ()
 insertPacketSet px (PacketSet pxs) = do
   let key = position px
@@ -345,7 +352,7 @@ insertPacketSet px (PacketSet pxs) = do
 
 -- | Obtain the number of packets in a 'PacketSet'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 lengthPacketSet :: PacketSet a -> STM Int
 lengthPacketSet (PacketSet pxs) = TMap.length pxs
 
@@ -353,7 +360,7 @@ lengthPacketSet (PacketSet pxs) = TMap.length pxs
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype PacketReader a = PacketReader
   {unPacketReader :: ReaderT PacketReaderEnv (ExceptT ParseError IO) a}
   deriving newtype (Functor, Applicative, Monad)
@@ -362,7 +369,7 @@ newtype PacketReader a = PacketReader
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data PacketReaderEnv = PacketReaderEnv
   { queue :: {-# UNPACK #-} !(TQueue ByteString)
   , packets :: {-# UNPACK #-} !(PacketSet ByteString)

--- a/src/Network/GRPC/MQTT/Message/Packet.hs
+++ b/src/Network/GRPC/MQTT/Message/Packet.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Packet
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/Request.hs
+++ b/src/Network/GRPC/MQTT/Message/Request.hs
@@ -1,7 +1,14 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TemplateHaskell #-}
 
--- | Definitions for the 'Request' message type.
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.Request
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Definitions for the 'Request' message type.
 --
 -- = Request Wire Format
 --
@@ -97,7 +104,7 @@
 -- @SearchRequest@ sent by the client. The raw 'ByteString' @SearchRequest@
 -- message can then be provided to @callSearchRPC@ to complete the request.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.Request
   ( -- * Requests
     Request (Request, message, options, timeout, metadata),
@@ -176,7 +183,7 @@ import Proto3.Wire.Types.Extra (RecordField)
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 fromMQTTRequest ::
   HasDefault rqt =>
   ProtoOptions ->
@@ -199,7 +206,7 @@ fromMQTTRequest options = \case
 --
 -- >>> wireEncodeRequest ~ wireWrapRequest . fmap toStrict toLazyByteString
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireEncodeRequest :: Message a => WireEncodeOptions -> Request a -> LByteString
 wireEncodeRequest options x =
   let message :: Request ByteString
@@ -208,7 +215,7 @@ wireEncodeRequest options x =
 
 -- | Like 'wireEncodeRequest', but the resulting 'ByteString' is strict.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireEncodeRequest' :: Message a => WireEncodeOptions -> Request a -> ByteString
 wireEncodeRequest' options x =
   let message :: Request ByteString
@@ -221,20 +228,20 @@ wireEncodeRequest' options x =
 -- If the given request's 'message' is not a valid wire binary, then it is very
 -- likely the resulting 'ByteString' can never be decoded.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireWrapRequest :: Request ByteString -> LByteString
 wireWrapRequest request = Encode.toLazyByteString (wireBuildRequest request)
 
 -- | Like 'wireWrapRequest', but the resulting 'ByteString' is strict.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireWrapRequest' :: Request ByteString -> ByteString
 wireWrapRequest' request = toStrict (wireWrapRequest request)
 
 -- | 'MessageBuilder' capable of partially serializing a 'Request'. The wrapped
 -- 'message' 'ByteString' __must__ be a valid wire binary.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireBuildRequest :: Request ByteString -> MessageBuilder
 wireBuildRequest rqt =
   wireBuildMessageField
@@ -276,7 +283,7 @@ wireBuildRequest rqt =
 -- | Partially decodes a 'Request' message, leaving wrapped 'message' in wire
 -- format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireUnwrapRequest ::
   MonadError ParseError m =>
   ByteString ->
@@ -286,7 +293,7 @@ wireUnwrapRequest bytes = do
 
 -- | Parses a serialized 'Request' message.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireParseRequest :: Parser RawMessage (Request ByteString)
 wireParseRequest = do
   Request

--- a/src/Network/GRPC/MQTT/Message/Request.hs
+++ b/src/Network/GRPC/MQTT/Message/Request.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Request
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/Request/Core.hs
+++ b/src/Network/GRPC/MQTT/Message/Request/Core.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Request.Core
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/Request/Core.hs
+++ b/src/Network/GRPC/MQTT/Message/Request/Core.hs
@@ -1,8 +1,15 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
--- | Core module defining the 'Request' type and 'Request' instances.
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.Request.Core
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Core module defining the 'Request' type and 'Request' instances.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.Request.Core
   ( -- * Request
     Request (Request, message, options, timeout, metadata),
@@ -30,7 +37,7 @@ import Network.GRPC.MQTT.Option (ProtoOptions)
 -- dictionary of gRPC metadata bound to the request, and properties configuring
 -- how the request is handled.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data Request msg = Request
   { -- | The request's 'message' is a type representing the protocol buffer
     -- message needed to perform the RPC call the client is requesting.
@@ -54,7 +61,7 @@ data Request msg = Request
   deriving stock (Eq, Ord, Show)
   deriving stock (Data, Generic, Typeable)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Functor Request where
   fmap f (Request x opts to ms) = Request (f x) opts to ms
   {-# INLINE fmap #-}

--- a/src/Network/GRPC/MQTT/Message/Response.hs
+++ b/src/Network/GRPC/MQTT/Message/Response.hs
@@ -1,5 +1,14 @@
 {-# LANGUAGE RecordWildCards #-}
 
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.AuxControl
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.Response
   ( -- * Wire Encoding
 

--- a/src/Network/GRPC/MQTT/Message/Response.hs
+++ b/src/Network/GRPC/MQTT/Message/Response.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE RecordWildCards #-}
 
 -- |
--- Module      :  Network.GRPC.MQTT.Message.AuxControl
+-- Module      :  Network.GRPC.MQTT.Message.Response
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/Stream.hs
+++ b/src/Network/GRPC/MQTT/Message/Stream.hs
@@ -1,3 +1,12 @@
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.Stream
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.Stream
   ( -- * Stream Chunks
     WrappedStreamChunk (Chunk, Empty, Error),
@@ -77,7 +86,7 @@ pattern Empty = Proto.WrappedStreamChunk Nothing
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireEncodeStreamChunk ::
   WireEncodeOptions ->
   Maybe (Vector ByteString) ->
@@ -89,7 +98,7 @@ wireEncodeStreamChunk options chunks =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireWrapStreamChunk :: Maybe (Vector ByteString) -> WrappedStreamChunk
 wireWrapStreamChunk (Just cxs) = Chunk cxs
 wireWrapStreamChunk Nothing = Empty
@@ -98,7 +107,7 @@ wireWrapStreamChunk Nothing = Empty
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireUnwrapStreamChunk ::
   MonadError RemoteError m =>
   WireDecodeOptions ->

--- a/src/Network/GRPC/MQTT/Message/Stream.hs
+++ b/src/Network/GRPC/MQTT/Message/Stream.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Stream
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Message/TH.hs
+++ b/src/Network/GRPC/MQTT/Message/TH.hs
@@ -1,12 +1,19 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 -- See [NOTE: Enforcing Message Splice Order]
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
--- | Definitions of template haskell splices used by 'Network.GRPC.MQTT.Message'
+-- |
+-- Module      :  Network.GRPC.MQTT.Message.TH
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Definitions of template haskell splices used by 'Network.GRPC.MQTT.Message'
 -- message types.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Message.TH
   ( -- * Record Introspection
     reifyFieldNumber,

--- a/src/Network/GRPC/MQTT/Message/TH.hs
+++ b/src/Network/GRPC/MQTT/Message/TH.hs
@@ -5,7 +5,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.TH
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Option.hs
+++ b/src/Network/GRPC/MQTT/Option.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Option
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Option.hs
+++ b/src/Network/GRPC/MQTT/Option.hs
@@ -5,10 +5,18 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
--- | This module defines the 'ProtoOptions' record and functions related to
+-- |
+-- Module      :  Network.GRPC.MQTT.Option
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module defines the 'ProtoOptions' record and functions related to
 -- protobuf options specific to gRPC-MQTT.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Option
   ( -- * ProtoOptions
     ProtoOptions
@@ -94,7 +102,7 @@ import Proto3.Wire.Decode.Extra qualified as Decode
 -- }
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ProtoOptions = ProtoOptions
   { -- | TODO
     rpcBatchStream :: Batched
@@ -106,7 +114,7 @@ data ProtoOptions = ProtoOptions
   deriving stock (Eq, Data, Generic, Lift, Ord, Show)
   deriving anyclass (Named)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Message ProtoOptions where
   encodeMessage = wireBuildProtoOptions
 
@@ -119,7 +127,7 @@ instance Message ProtoOptions where
 -- | The default options used at the file, service, and method level if no
 -- options are set explicitly.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 defaultProtoOptions :: ProtoOptions
 defaultProtoOptions =
   ProtoOptions
@@ -132,13 +140,13 @@ defaultProtoOptions =
 
 -- | Is client-side message compression enabled?
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isClientCompressed :: ProtoOptions -> Bool
 isClientCompressed opts = isJust (rpcClientCLevel opts)
 
 -- | Is message compression enabled on the remote client?
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isRemoteCompressed :: ProtoOptions -> Bool
 isRemoteCompressed opts = isJust (rpcServerCLevel opts)
 
@@ -147,7 +155,7 @@ isRemoteCompressed opts = isJust (rpcServerCLevel opts)
 -- | The protobuf type repesenting the protocol buffer data representation of a
 -- 'CLevel' value.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toProtoType :: Proxy# ProtoOptions -> [DotProtoField]
 toProtoType _ =
   [ mkfield @Batched 1 "rpc_batch_stream"
@@ -165,13 +173,13 @@ toProtoType _ =
 
 -- | Serializes a 'ProtoOptions' to a 'LByteString' in the wire binary format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireEncodeProtoOptions :: ProtoOptions -> LByteString
 wireEncodeProtoOptions = Encode.toLazyByteString . wireBuildProtoOptions 0
 
 -- | Like 'wireEncodeProtoOptions', but returns a strict 'ByteString'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireEncodeProtoOptions' :: ProtoOptions -> ByteString
 wireEncodeProtoOptions' = toStrict . wireEncodeProtoOptions
 
@@ -181,7 +189,7 @@ wireEncodeProtoOptions' = toStrict . wireEncodeProtoOptions
 -- To serialize a 'ProtoOptions' as a standalone message (rather than a field
 -- embedded within a message), a 'FieldNumber' @0@ should be given.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireBuildProtoOptions :: FieldNumber -> ProtoOptions -> MessageBuilder
 wireBuildProtoOptions n ProtoOptions{..} =
   let varints :: [Word64]
@@ -196,13 +204,13 @@ wireBuildProtoOptions n ProtoOptions{..} =
 
 -- | Decodes 'ProtoOptions' record from a 'ByteString'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireDecodeProtoOptions :: ByteString -> Either ParseError ProtoOptions
 wireDecodeProtoOptions = Decode.parse (Decode.at wireParseProtoOptions 0)
 
 -- | Message field parser capable of deserializing a 'ProtoOptions' record.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireParseProtoOptions :: Parser RawField ProtoOptions
 wireParseProtoOptions =
   Decode.catchE parseProtoOptions \err ->

--- a/src/Network/GRPC/MQTT/Option/Batched.hs
+++ b/src/Network/GRPC/MQTT/Option/Batched.hs
@@ -1,7 +1,15 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
--- | This module exports the 'Batched' datatype.
+-- |
+-- Module      :  Network.GRPC.MQTT.Option.Batched
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module exports the 'Batched' datatype.
 --
 -- == Batched Streaming
 --
@@ -51,7 +59,7 @@
 -- };
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Option.Batched
   ( -- * Batched
     -- $option-batched
@@ -91,7 +99,7 @@ import Network.GRPC.MQTT.Proto (ProtoDatum)
 -- | 'Batched' is a boolean indicating whether gRPC streams should batch packets
 -- before publishing over MQTT.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype Batched = Batch {getBatched :: Bool}
   deriving newtype (Primitive, ProtoDatum)
   deriving stock (Data, Eq, Ord, Generic, Lift, Typeable)
@@ -101,7 +109,7 @@ newtype Batched = Batch {getBatched :: Bool}
 --
 -- @'Batched' == 'Batch' 'True'@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 pattern Batched :: Batched
 pattern Batched = Batch True
 
@@ -109,7 +117,7 @@ pattern Batched = Batch True
 --
 -- @'Unbatched' == 'Batch' 'False'@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 pattern Unbatched :: Batched
 pattern Unbatched = Batch False
 
@@ -120,12 +128,12 @@ pattern Unbatched = Batch False
 --
 -- @'minBound' == 'Batched'@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance Bounded Batched where
   minBound = Unbatched
   maxBound = Batched
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Enum Batched where
   toEnum 1 = Batched
   toEnum _ = Unbatched
@@ -139,12 +147,12 @@ instance Enum Batched where
 -- 'show' 'Unbatched' == "Unbatched"
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance Show Batched where
   show Unbatched = "Unbatched"
   show Batched = "Batched"
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Ppr Batched where
   ppr x = Ppr.text (show x)
 
@@ -154,7 +162,7 @@ instance Ppr Batched where
 -- 'def' == 'Batch' 'False'
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance HasDefault Batched where
   def = Unbatched
 
@@ -170,6 +178,6 @@ instance HasDefault Batched where
 -- >>> toProtoValue Batched
 -- BoolLit True
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toProtoValue :: Batched -> DotProtoValue
 toProtoValue (Batch x) = DotProto.BoolLit x

--- a/src/Network/GRPC/MQTT/Option/Batched.hs
+++ b/src/Network/GRPC/MQTT/Option/Batched.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Option.Batched
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Option/CLevel.hs
+++ b/src/Network/GRPC/MQTT/Option/CLevel.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Option.CLevel
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Option/CLevel.hs
+++ b/src/Network/GRPC/MQTT/Option/CLevel.hs
@@ -4,7 +4,15 @@
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
--- | This module defines the 'CLevel' datatype. 'CLevel' represents a zstandard
+-- |
+-- Module      :  Network.GRPC.MQTT.Option.CLevel
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module defines the 'CLevel' datatype. 'CLevel' represents a zstandard
 -- compression level. Zstandard offers compression levels for controlling how 
 -- the algorithm favors speed vs. compression ratio. The supported range for a
 -- compression levels is from 1 to 22. See [the "introduction" section of the 
@@ -12,7 +20,7 @@
 -- (https://raw.githack.com/facebook/zstd/release/doc/zstd_manual.html) for more
 -- information regarding zstandard compression levels.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Option.CLevel
   ( -- * CLevel
     CLevel (CLevel, getCLevel),
@@ -89,7 +97,7 @@ import Proto3.Wire.Decode.Extra qualified as Decode
 -- Constructing 'CLevel' should be done via 'toCLevel' unless the underlying
 -- 'Int' value is known to always be between @1@ and @22@ (inclusively).
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype CLevel = CLevel {getCLevel :: Int32}
   deriving stock (Data, Eq, Generic, Lift, Ord)
   deriving anyclass (Message)
@@ -99,27 +107,27 @@ newtype CLevel = CLevel {getCLevel :: Int32}
 --
 -- @'maxBound' == 'CLevel' 22@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance Bounded CLevel where
   minBound = CLevel 1
   maxBound = CLevel (fromIntegral @Int @Int32 Zstd.maxCLevel)
 
 -- | @'show' ('CLevel' 10) == "CLEVEL_10"@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance Show CLevel where
   show (CLevel x) = "CLEVEL_" ++ show x
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Ppr CLevel where
   ppr x = Ppr.text (show x)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoEnum CLevel where
   toProtoEnumMay = toCLevel
   fromProtoEnum = fromCLevel
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Finite CLevel where
   enumerate _ = map makeEnum [1 .. 22]
     where
@@ -128,17 +136,17 @@ instance Finite CLevel where
 
 -- | @'nameOf' ('proxy#' :: 'Proxy#' 'CLevel') == \"CLevel\"@
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 instance Named CLevel where
   nameOf _ = "CLevel"
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Primitive CLevel where
   encodePrimitive = Encode.enum
   decodePrimitive = Decode.enum >>= either throwCLevelBoundsError pure
   primType = toPrimType
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum CLevel where
   datumRep = DRepIdent
 
@@ -151,14 +159,14 @@ instance ProtoDatum CLevel where
 
 -- | Convert a 'CLevel' value to an 'Integral' value.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 fromCLevel :: Integral a => CLevel -> a
 fromCLevel (CLevel x) = fromIntegral x
 
 -- | Constructs a 'CLevel' from an 'Integral' value, if the value corresponds to
 -- compression level that is supported by zstandard, otherwise yields 'Nothing'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toCLevel :: Integral a => a -> Maybe CLevel
 toCLevel n
   | isCLevel n = Just (CLevel (fromIntegral n))
@@ -169,7 +177,7 @@ toCLevel n
 -- | Predicate that tests if a given integral value corresponds to a compression
 --  level supported by zstandard.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isCLevel :: Integral a => a -> Bool
 isCLevel x = fromCLevel minBound <= x && x <= fromCLevel maxBound
 
@@ -177,7 +185,7 @@ isCLevel x = fromCLevel minBound <= x && x <= fromCLevel maxBound
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 showMaybeCLevel :: Maybe CLevel -> String
 showMaybeCLevel x = maybe "CLEVEL_DISABLED" show x
 
@@ -210,7 +218,7 @@ showMaybeCLevel x = maybe "CLEVEL_DISABLED" show x
 -- >>> toProtoValue (CLevel 10)
 -- Identifier (Single "CLEVEL_10")
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toProtoValue :: CLevel -> DotProtoValue
 toProtoValue x = DotProto.Identifier (DotProto.Single (show x))
 
@@ -220,7 +228,7 @@ toProtoValue x = DotProto.Identifier (DotProto.Single (show x))
 -- >>> toPrimType proxy#
 -- Named (Dots (Path {components = "haskell" :| ["grpc","mqtt","CLevel"]}))
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toPrimType :: Proxy# CLevel -> DotProtoPrimType
 toPrimType p =
   let path :: Path
@@ -233,7 +241,7 @@ toPrimType p =
 -- failed to be deserialized because the parsed enum value was outside of the
 -- supported range for compression levels.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwCLevelBoundsError :: Show a => a -> Parser i b
 throwCLevelBoundsError x =
   let issue :: ParseError

--- a/src/Network/GRPC/MQTT/Proto.hs
+++ b/src/Network/GRPC/MQTT/Proto.hs
@@ -2,13 +2,21 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
--- | This module defines functions used by @grpc-mqtt@ internals for:
+-- |
+-- Module      :  Network.GRPC.MQTT.Proto
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module defines functions used by @grpc-mqtt@ internals for:
 --
 -- * Handling IO for protocol buffers.
 --
 -- * Manipulating the protobuf syntax trees.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Proto
   ( -- * Proto IO
     openProtoFileIO,
@@ -130,7 +138,7 @@ import Turtle qualified
 -- Raises 'ProtoIOError' 'IO' exceptions if the 'Turtle.FilePath' does not refer
 -- to a valid *.proto file that can be read.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 openProtoFileIO :: Turtle.FilePath -> IO DotProto
 openProtoFileIO filepath = do
   -- Test that the path @filepath@ exists.
@@ -158,14 +166,14 @@ openProtoFileIO filepath = do
 -- | 'ProtoIOError' represents an IO error that occurs when reading or parsing
 -- the contents of a *.proto file.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ProtoIOError = ProtoIOError
   { ioeFilePath :: Turtle.FilePath
   , ioeErrorTag :: ProtoIOErrorTag
   }
   deriving stock (Eq, Ord)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Show ProtoIOError where
   show (ProtoIOError filepath tag) =
     let locS = "(" ++ Turtle.encodeString filepath ++ "): "
@@ -173,7 +181,7 @@ instance Show ProtoIOError where
      in "protobuf IO error" ++ locS ++ tagS
   {-# INLINE show #-}
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Exception ProtoIOError where
   displayException ioe = show ioe
   {-# INLINE displayException #-}
@@ -181,28 +189,28 @@ instance Exception ProtoIOError where
 -- | Throws a 'ProtoIOError' IO exception with the 'InvalidProtoExtension' tag
 -- for the given filepath.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwProtoInvalidExtensionIO :: Turtle.FilePath -> IO a
 throwProtoInvalidExtensionIO = throwProtoIO ProtoInvalidExtension
 
 -- | Throws a 'ProtoIOError' IO exception with the 'ProtoFileDoesNotExist' tag
 -- for the given filepath.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwProtoDoesNotExistIO :: Turtle.FilePath -> IO a
 throwProtoDoesNotExistIO = throwProtoIO ProtoFileDoesNotExist
 
 -- | Throws a 'ProtoIOError' IO exception with the 'ProtoPathIsDirectory' tag
 -- for the given filepath.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwProtoPathIsDirectoryIO :: Turtle.FilePath -> IO a
 throwProtoPathIsDirectoryIO = throwProtoIO ProtoPathIsDirectory
 
 -- | Throws a 'CompileError' as an 'ErrorCall' IO exception using the filepath
 --  as the 'ErrorCall' location.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwCompileErrorIO :: Turtle.FilePath -> CompileError -> IO a
 throwCompileErrorIO filepath err =
   let issue :: ErrorCall
@@ -216,14 +224,14 @@ throwProtoIO tag filepath = throwIO (ProtoIOError filepath tag)
 
 -- | An enumeration of error codes that 'ProtoIOError' is tagged with.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ProtoIOErrorTag
   = ProtoInvalidExtension
   | ProtoFileDoesNotExist
   | ProtoPathIsDirectory
   deriving stock (Enum, Eq, Ord, Show)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Exception ProtoIOErrorTag where
   displayException ProtoInvalidExtension = "filepath must have a *.proto extension"
   displayException ProtoFileDoesNotExist = "proto filepath not found (does not exist)"
@@ -234,7 +242,7 @@ instance Exception ProtoIOErrorTag where
 
 -- | Obtain the kind of 'DatumRep' used to represent a 'DotProtoValue'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 datumRepOf :: DotProtoValue -> DatumRep
 datumRepOf DotProto.BoolLit{} = DRepBoolean
 datumRepOf DotProto.FloatLit{} = DRepDecimal
@@ -255,7 +263,7 @@ datumRepOf DotProto.StringLit{} = DRepString
 -- >>> castDatumRepWith @String DRepString (DotProto.BoolLit True)
 -- Nothing
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 castDatumRepWith :: forall a. Typeable a => DatumRep -> DotProtoValue -> Maybe a
 castDatumRepWith datrep val =
   case datrep of
@@ -285,7 +293,7 @@ castDatumRepWith datrep val =
 -- | 'DatumRep' enumerates the /kinds/ of scalars that can be represented by a
 -- 'DotProtoValue' value.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data DatumRep
   = -- | Boolean representations correspond to the @bool@ .proto type.
     DRepBoolean
@@ -306,17 +314,17 @@ data DatumRep
 -- | 'ProtoDatum' is the class of types that can be obtained from a
 -- 'DotProtoValue' literal.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 class ProtoDatum a where
   -- | The type of protobuf literal used to represent a value of type @a@.
   --
-  -- @since 0.1.0.0
+  -- @since 1.0.0
   datumRep :: DatumRep
 
   -- | A type-safe cast operation from a 'DotProtoValue' literal to a value of
   -- the type @a@.
   --
-  -- @since 0.1.0.0
+  -- @since 1.0.0
   castDatum :: DotProtoValue -> Maybe a
   castDatum val = castDatumRepWith (datumRep @a) val
   {-# INLINE castDatum #-}
@@ -324,29 +332,29 @@ class ProtoDatum a where
 
   {-# MINIMAL datumRep #-}
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum Bool where
   datumRep = DRepBoolean
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum Double where
   datumRep = DRepDecimal
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum Int where
   datumRep = DRepInteger
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum String where
   datumRep = DRepString
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum ByteString where
   datumRep = DRepString
 
   castDatum x = encodeUtf8 <$> castDatum @String x
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance ProtoDatum DotProtoIdentifier where
   datumRep = DRepIdent
 
@@ -355,7 +363,7 @@ instance ProtoDatum DotProtoIdentifier where
 -- | Splits a 'DotProtoIdentifier' into a list of the names that the identifier
 -- is comprised of.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toProtoNameList :: DotProtoIdentifier -> [String]
 toProtoNameList idt = case idt of
   DotProto.Anonymous -> []
@@ -374,7 +382,7 @@ toProtoNameList idt = case idt of
 -- >>> showProtoId (DotProto.Dots (DotProto.Path ["package", "identifier"]))
 -- "package.identifier"
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 showProtoId :: DotProtoIdentifier -> String
 showProtoId idt =
   let parts :: [String]
@@ -387,7 +395,7 @@ showProtoId idt =
 
 -- | 'ProtoOptionSet' is a collection of protobuf options.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype ProtoOptionSet = ProtoOptionSet
   {getProtoOptionSet :: Map DotProtoIdentifier DotProtoValue}
   deriving
@@ -399,7 +407,7 @@ newtype ProtoOptionSet = ProtoOptionSet
 -- If an option with the same 'DotProtoIdentifier' is an element of the
 -- 'ProtoOptionSet', then a 'ProtoOptionAlreadySet' error is raised.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insertOption ::
   MonadError ProtoOptionError m =>
   DotProtoOption ->
@@ -417,7 +425,7 @@ insertOption opt opts =
 -- If an option with the same 'DotProtoIdentifier' is an element of the
 -- 'ProtoOptionSet', then the associated 'DotProtoValue' is replaced.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insertOption' :: DotProtoOption -> ProtoOptionSet -> ProtoOptionSet
 insertOption' opt (ProtoOptionSet kvs) = do
   let key = DotProto.dotProtoOptionIdentifier opt
@@ -426,14 +434,14 @@ insertOption' opt (ProtoOptionSet kvs) = do
 
 -- | Lookup the 'DotProtoValue' set for a protobuf option by name.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 lookupOption :: DotProtoIdentifier -> ProtoOptionSet -> Maybe DotProtoValue
 lookupOption key (ProtoOptionSet kvs) = Map.lookup key kvs
 
 -- | Is an option with the 'DotProtoIdentifier' an element of the
 -- 'ProtoOptionSet'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 memberOption :: DotProtoIdentifier -> ProtoOptionSet -> Bool
 memberOption key (ProtoOptionSet kvs) = Map.member key kvs
 
@@ -442,7 +450,7 @@ memberOption key (ProtoOptionSet kvs) = Map.member key kvs
 -- | 'ProtoOptionError' represents the errors that improper protobuf option
 -- usage can produce.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ProtoOptionError
   = -- | 'ProtoOptionAlreadySet' errors are emitted when protobuf declarations
     -- when multiple values are set for the same option.
@@ -475,7 +483,7 @@ data ProtoOptionError
     OptionValueTypeMismatch DatumRep DotProtoOption
   deriving stock (Data, Eq, Generic, Ord, Show, Typeable)
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Exception ProtoOptionError where
   displayException (ProtoOptionAlreadySet idt) =
     "the option " ++ showProtoId idt ++ " was already set."
@@ -493,13 +501,13 @@ instance Exception ProtoOptionError where
 
 -- | 'for'-style traversal over the 'ProtoServices' defined in a 'DotProto'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 servicesOf :: Applicative f => DotProto -> (ProtoService -> f a) -> f [a]
 servicesOf dotproto = for (getFileServices dotproto)
 
 -- | Accesses the list of services defined in the 'DotProto'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getFileServices :: DotProto -> [ProtoService]
 getFileServices dotproto =
   foldMap toService (DotProto.protoDefinitions dotproto)
@@ -513,7 +521,7 @@ getFileServices dotproto =
 -- If the 'DotProto' sets the same file-level option more than once, a
 -- 'ProtoOptionAlreadySet' error is raised.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getFileOptions :: MonadError ProtoOptionError m => DotProto -> m ProtoOptionSet
 getFileOptions dotproto = foldrM insertOption mempty (DotProto.protoOptions dotproto)
 
@@ -521,7 +529,7 @@ getFileOptions dotproto = foldrM insertOption mempty (DotProto.protoOptions dotp
 
 -- | 'ProtoService' is a record representing a protobuf service definition.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data ProtoService = ProtoService
   { serviceName :: DotProtoIdentifier
   , serviceDefs :: [DotProtoServicePart]
@@ -530,13 +538,13 @@ data ProtoService = ProtoService
 
 -- | 'for'-style traversal over the 'RPCMethod' defined in a 'ProtoService'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 methodsOf :: Applicative f => ProtoService -> (RPCMethod -> f a) -> f [a]
 methodsOf dotproto = for (getServiceMethods dotproto)
 
 -- | Accesses the 'RPCMethods' defined by a 'ProtoService'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getServiceMethods :: ProtoService -> [RPCMethod]
 getServiceMethods (ProtoService _ ps) = foldr toRPCs mempty ps
   where
@@ -549,7 +557,7 @@ getServiceMethods (ProtoService _ ps) = foldr toRPCs mempty ps
 -- If the 'ProtoService' sets the same service-level option more than once, a
 -- 'ProtoOptionAlreadySet' error is thrown.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getServiceOptions ::
   forall m.
   MonadError ProtoOptionError m =>
@@ -565,7 +573,7 @@ getServiceOptions (ProtoService _ ps) = foldrM toOptions mempty ps
 
 -- | Querys a 'RPCMethod' for its gRPC method type.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getMethodType :: RPCMethod -> GRPCMethodType
 getMethodType rpc =
   case DotProto.rpcMethodRequestStreaming rpc of
@@ -583,7 +591,7 @@ getMethodType rpc =
 -- If the 'RPCMethod' sets the same method-level option more than once, a
 -- 'ProtoOptionAlreadySet' error is thrown.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 getMethodOptions :: MonadError ProtoOptionError m => RPCMethod -> m ProtoOptionSet
 getMethodOptions rpc = foldrM insertOption mempty (DotProto.rpcMethodOptions rpc)
 
@@ -591,7 +599,7 @@ getMethodOptions rpc = foldrM insertOption mempty (DotProto.rpcMethodOptions rpc
 
 -- | Displays a 'CompileError' in a legible format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 showCompileError :: CompileError -> String
 showCompileError = \case
   DotProto.CircularImport filepath ->
@@ -654,7 +662,7 @@ showCompileError = \case
 
 -- | Displays a 'CompileError' in a legible format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 showParseError :: ParseError -> String
 showParseError = \case
   Wire.WireTypeError msg -> toString msg

--- a/src/Network/GRPC/MQTT/Proto.hs
+++ b/src/Network/GRPC/MQTT/Proto.hs
@@ -5,7 +5,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Proto
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Proto/TH.hs
+++ b/src/Network/GRPC/MQTT/Proto/TH.hs
@@ -1,6 +1,15 @@
--- | Template haskell functions for creating splices from protocol buffers.
+
+-- |
+-- Module      :  Network.GRPC.MQTT.Proto.TH
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Template haskell functions for creating splices from protocol buffers.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Proto.TH
   ( -- * Quotation
 
@@ -48,7 +57,7 @@ import Network.GRPC.MQTT.Proto (showCompileError, showProtoId)
 -- Aborts the current splice's computation with a "not in scope" error if no
 -- type constructor could be found.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 queryProtoTypeNameQ :: DotProtoIdentifier -> Q Name
 queryProtoTypeNameQ typeId = do
   -- Apply type-casing (pascal case) to @typeId@ and perform namespace lookup.
@@ -62,32 +71,32 @@ queryProtoTypeNameQ typeId = do
 
 -- | Applies type-case (or pascal case) formatting to the string.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 formatTypeNameQ :: String -> Q String
 formatTypeNameQ nm = hoistCompileErrorQ (DotProto.typeLikeName nm)
 
 -- | Obtain the name of a proto3 package from a 'DotProtoPacketSpec'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 protoPackageIdQ :: DotProtoPackageSpec -> Q DotProtoIdentifier
 protoPackageIdQ spec = hoistCompileErrorQ (DotProto.protoPackageName spec)
 
 -- | Accesses the unqualified base name of the 'DotProtoIdentifier'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toProtoNameQ :: DotProtoIdentifier -> Q String
 toProtoNameQ idt = hoistCompileErrorQ (DotProto.dpIdentUnqualName idt)
 
 -- | Accesses the qualified name of the 'DotProtoIdentifier'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 toQualProtoNameQ :: DotProtoIdentifier -> Q String
 toQualProtoNameQ idt = hoistCompileErrorQ (DotProto.dpIdentQualName idt)
 
 -- | Constructs a qualified RPC name from the 'DotProtoIdentifier' of the RPC
 -- and the service the RPC belongs to.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeServiceFieldNameQ :: DotProtoIdentifier -> DotProtoIdentifier -> Q Name
 makeServiceFieldNameQ svcId rpcId = do
   svcNm <- toProtoNameQ svcId
@@ -98,7 +107,7 @@ makeServiceFieldNameQ svcId rpcId = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwTypeNotInScopeQ :: DotProtoIdentifier -> Q a
 throwTypeNotInScopeQ idt =
   let idtS :: String
@@ -108,14 +117,14 @@ throwTypeNotInScopeQ idt =
 -- | Fails 'Q' reporting the compile error with the location information for the
 -- current splice context.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwCompileErrorQ :: CompileError -> Q a
 throwCompileErrorQ err = throwLocationQ (showCompileError err)
 
 -- | Fails 'Q' reporting the given error annotated with formatted location
 -- information for the current splice context.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwLocationQ :: String -> Q a
 throwLocationQ issue = do
   loc <- TH.location

--- a/src/Network/GRPC/MQTT/Proto/TH.hs
+++ b/src/Network/GRPC/MQTT/Proto/TH.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Proto.TH
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
--- Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
-
--- | gRPC-MQTT remote clients.
+-- |
+-- Module      :  Network.GRPC.MQTT.RemoteClient
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- gRPC-MQTT remote clients.
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.RemoteClient
   ( runRemoteClient,
     runRemoteClientWithConnect,
@@ -226,7 +230,7 @@ handleControlMessage logger handle msg =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 handleRequest :: SessionHandle -> Session ()
 handleRequest handle = do
   let queue = hdlRqtQueue handle
@@ -324,7 +328,7 @@ publishGRPCIOError options err =
 
 -- | Encodes the given 'RemoteError', and publishes it to the topic provided.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 publishRemoteError :: WireEncodeOptions -> RemoteError -> Session ()
 publishRemoteError options err = do
   -- TODO: note why remote error cannot take encoding options

--- a/src/Network/GRPC/MQTT/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.RemoteClient
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -1,13 +1,18 @@
 {-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE RecursiveDo #-}
 {-# LANGUAGE StandaloneKindSignatures #-}
 
 -- |
+-- Module      :  Network.GRPC.MQTT.RemoteClient.Session
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.RemoteClient.Session
   ( -- * Session
     Session (Session),
@@ -110,7 +115,7 @@ import Network.GRPC.MQTT.Types (ClientHandler, MethodMap)
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype Session a = Session
   {unSession :: ReaderT SessionConfig IO a}
   deriving
@@ -122,7 +127,7 @@ newtype Session a = Session
 
 -- | Evaluates a 'Session' with the given 'SessionConfig'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 runSessionIO :: Session a -> SessionConfig -> IO a
 runSessionIO session = runReaderT (unSession session)
 
@@ -138,7 +143,7 @@ runSessionIO session = runReaderT (unSession session)
 -- The 'SessionHandle' created by 'withSession' is freed from the sessions map
 -- after the inner function's timeout period expires or yields a result.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 withSession :: (SessionHandle -> Session ()) -> Session ()
 withSession k = do
   config <- ask
@@ -153,7 +158,7 @@ withSession k = do
 -- | Querys the ambient sessions map for session with the given session id
 -- 'Topic'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 lookupSessionM :: Topic -> Session (Maybe SessionHandle)
 lookupSessionM sid = do
   sessions <- asks cfgSessions
@@ -162,7 +167,7 @@ lookupSessionM sid = do
 -- | Registers a new 'SessionHandle' with the given session id 'Topic' with the
 -- ambient sessions map.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insertSessionM :: Topic -> SessionHandle -> Session ()
 insertSessionM sid handle = do
   sessions <- asks cfgSessions
@@ -171,7 +176,7 @@ insertSessionM sid handle = do
 -- | Frees the 'SessionHandle' with the given session id 'Topic' from the ambient
 -- sessions map, if one exists.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 deleteSessionM :: Topic -> Session ()
 deleteSessionM sid = do
   sessions <- asks cfgSessions
@@ -181,7 +186,7 @@ deleteSessionM sid = do
 
 -- | Write a debug log to the ambient session's logger.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logDebug :: (MonadReader SessionConfig m, MonadIO m) => Text -> Text -> m ()
 logDebug ctx msg = do
   logger <- asks cfgLogger
@@ -189,7 +194,7 @@ logDebug ctx msg = do
 
 -- | Write an error log to the ambient session's logger.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 logError :: (MonadReader SessionConfig m, MonadIO m) => Text -> Text -> m ()
 logError ctx msg = do
   logger <- asks cfgLogger
@@ -202,7 +207,7 @@ logError ctx msg = do
 -- | Queries the session's method map for the 'ClientHandler' mapped to the
 -- session's service and RPC name.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askMethod :: Session (Maybe ClientHandler)
 askMethod =
   HashMap.lookup
@@ -211,7 +216,7 @@ askMethod =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askMethodKey :: Session ByteString
 askMethodKey = do
   -- 'askMethodTopic' renders the topic as "service/rpc", but a session's
@@ -225,7 +230,7 @@ askMethodKey = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askMethodTopic :: Session Topic
 askMethodTopic =
   Topic.makeRPCMethodTopic
@@ -234,7 +239,7 @@ askMethodTopic =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askRequestTopic :: Session Topic
 askRequestTopic =
   Topic.makeRequestTopic
@@ -245,7 +250,7 @@ askRequestTopic =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askResponseTopic :: Session Topic
 askResponseTopic =
   Topic.makeResponseTopic
@@ -257,14 +262,14 @@ askResponseTopic =
 -- | Like 'makeControlFilter', but uses the base topic provided by session's
 -- ambient 'SessionConfig'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askControlFilter :: Session Filter
 askControlFilter = Topic.makeControlFilter <$> asks (topicBase . cfgTopics)
 
 -- | Like 'makeRequestFilter', but uses the base topic provided by session's
 -- ambient 'SessionConfig'.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 askRequestFilter :: Session Filter
 askRequestFilter = Topic.makeRequestFilter <$> asks (topicBase . cfgTopics)
 
@@ -272,7 +277,7 @@ askRequestFilter = Topic.makeRequestFilter <$> asks (topicBase . cfgTopics)
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data SessionHandle = SessionHandle
   { hdlThread :: Async ()
   , hdlRqtQueue :: TQueue ByteString
@@ -281,7 +286,7 @@ data SessionHandle = SessionHandle
 
 -- | Constructs a 'SessionHandle' monitoring from a request handler thread.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newSessionHandleIO :: Async () -> IO SessionHandle
 newSessionHandleIO thread = do
   SessionHandle thread 
@@ -290,7 +295,7 @@ newSessionHandleIO thread = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newWatchdogIO :: NominalDiffTime -> TMVar () -> IO ()
 newWatchdogIO period'sec var = do
   -- 'NominalDiffTime' is measured in unit-seconds. Here @period'sec@ is converted
@@ -311,7 +316,7 @@ newWatchdogIO period'sec var = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data SessionConfig = SessionConfig
   { cfgClient :: MQTTClient
   , cfgSessions :: TMap Topic SessionHandle
@@ -329,7 +334,7 @@ data SessionConfig = SessionConfig
 -- client sessions. 'SessionTopic' conversion functions (such as 'toRqtTopic') can
 -- be used to deconstruct a 'SessionTopic' into frequently used MQTT topic.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data SessionTopic = SessionTopic
   { topicBase :: {-# UNPACK #-} !Topic
   , topicSid :: {-# UNPACK #-} !Topic
@@ -342,7 +347,7 @@ data SessionTopic = SessionTopic
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 fromRqtTopic :: Topic -> Topic -> Maybe SessionTopic
 fromRqtTopic base topic = do
   ["grpc", "request", sid, escapedSvc, rpc] <- stripPrefix (Topic.split base) (Topic.split topic)

--- a/src/Network/GRPC/MQTT/RemoteClient/Session.hs
+++ b/src/Network/GRPC/MQTT/RemoteClient/Session.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.RemoteClient.Session
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Serial.hs
+++ b/src/Network/GRPC/MQTT/Serial.hs
@@ -1,3 +1,12 @@
+-- |
+-- Module      :  Network.GRPC.MQTT.Serial
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Serial
   ( -- * Wire Encoding Options
     WireEncodeOptions (WireEncodeOptions, encodeCLevel, encodeBatched),
@@ -43,7 +52,7 @@ import Network.GRPC.MQTT.Option.Batched qualified as Batched
 -- messages (instances of 'Message') should be serialized into the wire binary
 -- format.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data WireEncodeOptions = WireEncodeOptions
   { -- | If given, 'encodeCLevel' is the zstandard compression level that is
     -- used for compressing a protobuf message after it has been serialized.
@@ -61,7 +70,7 @@ data WireEncodeOptions = WireEncodeOptions
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 defaultEncodeOptions :: WireEncodeOptions
 defaultEncodeOptions =
   WireEncodeOptions
@@ -73,7 +82,7 @@ defaultEncodeOptions =
 -- | Obtain the wire encoding options that should be used client-side from a
 -- 'ProtoOptions' record.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientEncodeOptions :: ProtoOptions -> WireEncodeOptions
 makeClientEncodeOptions opts =
   WireEncodeOptions
@@ -84,7 +93,7 @@ makeClientEncodeOptions opts =
 -- | Obtain the wire encoding options that should be used by the remote client
 -- from a 'ProtoOptions' record.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeRemoteEncodeOptions :: ProtoOptions -> WireEncodeOptions
 makeRemoteEncodeOptions opts =
   WireEncodeOptions
@@ -96,7 +105,7 @@ makeRemoteEncodeOptions opts =
 
 -- | Is compression enabled for the 'WireEncodeOptions'?
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isEncodeCompressed :: WireEncodeOptions -> Bool
 isEncodeCompressed options = isJust (encodeCLevel options)
 
@@ -116,7 +125,7 @@ newtype WireDecodeOptions = WireDecodeOptions
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 defaultDecodeOptions :: WireDecodeOptions
 defaultDecodeOptions =
   WireDecodeOptions
@@ -144,6 +153,6 @@ makeRemoteDecodeOptions opts =
 
 -- | Is decompression enabled for the 'WireDecodeOptions'?
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 isDecodeCompressed :: WireDecodeOptions -> Bool
 isDecodeCompressed options = decodeDecompress options

--- a/src/Network/GRPC/MQTT/Serial.hs
+++ b/src/Network/GRPC/MQTT/Serial.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Serial
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -1,11 +1,14 @@
--- Copyright (c) 2021-2022 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE TemplateHaskell #-}
 
--- | TODO
+-- |
+-- Module      :  Network.GRPC.MQTT.TH.Client
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.TH.Client
   ( -- * TODO
     makeMQTTClientFuncs,
@@ -122,7 +125,7 @@ makeMQTTClientFuncs filepath = do
 -- makeClientHandlerSigQ (DotProto.Single "HandlerType")
 -- @
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientHandlerSigQ :: DotProtoIdentifier -> Q Type
 makeClientHandlerSigQ typeId = do
   typeNm <- queryProtoTypeNameQ typeId
@@ -132,7 +135,7 @@ makeClientHandlerSigQ typeId = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientHandlerExpQ ::
   DotProtoIdentifier ->
   DotProtoIdentifier ->
@@ -150,7 +153,7 @@ makeClientHandlerExpQ pkgId svcId rpc optmap = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientMethodNameQ ::
   DotProtoIdentifier ->
   DotProtoIdentifier ->
@@ -174,7 +177,7 @@ makeClientMethodNameQ pkgId svcId rpcId = do
 -- >>> $(makeClientEndpointNameQ pkg svc >>= TH.stringE)
 -- "cool.proto.package.ServiceName"
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientEndpointNameQ :: DotProtoIdentifier -> DotProtoIdentifier -> Q String
 makeClientEndpointNameQ pkgId svcId = do
   pkgNm <- toQualProtoNameQ pkgId
@@ -188,7 +191,7 @@ makeClientEndpointNameQ pkgId svcId = do
 -- >>> $(makeClientHandlerNameQ idt >>= TH.stringE)
 -- "serviceNameMqttClient"
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeClientHandlerNameQ :: DotProtoIdentifier -> Q String
 makeClientHandlerNameQ svcId = do
   svcNm <- toProtoNameQ svcId

--- a/src/Network/GRPC/MQTT/TH/Client.hs
+++ b/src/Network/GRPC/MQTT/TH/Client.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.TH.Client
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.TH.Proto
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/TH/Proto.hs
+++ b/src/Network/GRPC/MQTT/TH/Proto.hs
@@ -1,14 +1,17 @@
--- Copyright (c) 2021-2022 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 
--- | TODO
+-- |
+-- Module      :  Network.GRPC.MQTT.TH.Proto
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.TH.Proto
   ( -- * Template Haskell
     openProtoFileQ,
@@ -113,7 +116,7 @@ import Network.GRPC.MQTT.Proto
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 openProtoFileQ :: Turtle.FilePath -> Q DotProto
 openProtoFileQ filepath = do
   dotproto <- liftIO (openProtoFileIO filepath)
@@ -122,7 +125,7 @@ openProtoFileQ filepath = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeProtoOptionMapQ :: DotProto -> Q ProtoOptionMap
 makeProtoOptionMapQ dotproto =
   case makeProtoOptionConfig dotproto of
@@ -131,7 +134,7 @@ makeProtoOptionMapQ dotproto =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 queryMethodOptionsQ :: RPCMethod -> ProtoOptionMap -> Q ProtoOptions
 queryMethodOptionsQ rpc optmap =
   case lookupProtoOptionMap rpc optmap of
@@ -142,26 +145,26 @@ queryMethodOptionsQ rpc optmap =
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype ProtoOptionMap = ProtoOptionMap
   {getProtoOptionConfig :: Map RPCMethod ProtoOptions}
   deriving (Eq, Ord, Show)
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 emptyProtoOptionMap :: ProtoOptionMap
 emptyProtoOptionMap = ProtoOptionMap Map.empty
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 lookupProtoOptionMap :: RPCMethod -> ProtoOptionMap -> Maybe ProtoOptions
 lookupProtoOptionMap key (ProtoOptionMap kvs) = Map.lookup key kvs
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 insertProtoOptionMap :: RPCMethod -> ProtoOptions -> ProtoOptionMap -> ProtoOptionMap
 insertProtoOptionMap key val (ProtoOptionMap kvs) = ProtoOptionMap (Map.insert key val kvs)
 
@@ -169,7 +172,7 @@ insertProtoOptionMap key val (ProtoOptionMap kvs) = ProtoOptionMap (Map.insert k
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 newtype OptionReader a = OptionReader
   { unOptionReader ::
       ReaderT OptionReaderCtx (StateT ProtoOptionMap (Except ProtoOptionError)) a
@@ -183,7 +186,7 @@ newtype OptionReader a = OptionReader
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data OptionReaderCtx = OptionReaderCtx
   { ctxOptionDefs :: ProtoOptions
   , ctxSetOptions :: ProtoOptionSet
@@ -191,7 +194,7 @@ data OptionReaderCtx = OptionReaderCtx
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeProtoOptionConfig :: DotProto -> Either ProtoOptionError ProtoOptionMap
 makeProtoOptionConfig dotproto = do
   opts <- getFileOptions dotproto
@@ -247,7 +250,7 @@ makeProtoOptionConfig dotproto = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 readFileProtoOptions :: OptionReader ProtoOptions
 readFileProtoOptions = do
   defs <- asks ctxOptionDefs
@@ -258,7 +261,7 @@ readFileProtoOptions = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 readServiceProtoOptions :: OptionReader ProtoOptions
 readServiceProtoOptions = do
   defs <- asks ctxOptionDefs
@@ -269,7 +272,7 @@ readServiceProtoOptions = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 readMethodProtoOptions :: OptionReader ProtoOptions
 readMethodProtoOptions = do
   defs <- asks ctxOptionDefs
@@ -282,7 +285,7 @@ readMethodProtoOptions = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 queryOptionConfig :: ProtoDatum a => String -> a -> OptionReader a
 queryOptionConfig nm def = do
   opts <- asks ctxSetOptions
@@ -294,7 +297,7 @@ queryOptionConfig nm def = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 queryOptionConfigM ::
   ProtoDatum a =>
   String ->
@@ -312,7 +315,7 @@ queryOptionConfigM nm def = do
 
 -- | TODO
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 castProtoOption :: forall a. ProtoDatum a => DotProtoOption -> OptionReader a
 castProtoOption opt =
   let val :: DotProtoValue

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.TH.RemoteClient
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/TH/RemoteClient.hs
+++ b/src/Network/GRPC/MQTT/TH/RemoteClient.hs
@@ -1,8 +1,14 @@
--- Copyright (c) 2021-2022 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE TemplateHaskell #-}
 
+-- |
+-- Module      :  Network.GRPC.MQTT.TH.RemoteClient
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.TH.RemoteClient
   ( Client,
     MethodMap,

--- a/src/Network/GRPC/MQTT/Topic.hs
+++ b/src/Network/GRPC/MQTT/Topic.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Topic
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Topic.hs
+++ b/src/Network/GRPC/MQTT/Topic.hs
@@ -1,9 +1,16 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
--- | This module exports templates for constructing frequently MQTT topics and
+-- |
+-- Module      :  Network.GRPC.MQTT.Topic
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- This module exports templates for constructing frequently MQTT topics and
 -- filters that are frequently needed by clients and remote clients.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Network.GRPC.MQTT.Topic
   ( -- * MQTT Topic Templates
     -- $mqtt-topic-templates
@@ -42,7 +49,7 @@ import Relude
 -- >>> makeRPCMethodTopic "service.Name" "rpc.Method"
 -- Topic {unTopic = "service.Name/rpc.Method"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeRPCMethodTopic :: Topic -> Topic -> Topic
 makeRPCMethodTopic svc rpc = svc <> rpc
 
@@ -52,7 +59,7 @@ makeRPCMethodTopic svc rpc = svc <> rpc
 -- >>> makeControlTopic "base.topic" "i1X-Kk7cjUkpeEswPfP9kIid"
 -- Topic {unTopic = "base.topic/grpc/session/i1X-Kk7cjUkpeEswPfP9kIid/control"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeControlTopic :: Topic -> Topic -> Topic
 makeControlTopic base sid = makeResponseTopic base sid <> "control"
 
@@ -63,7 +70,7 @@ makeControlTopic base sid = makeResponseTopic base sid <> "control"
 -- >>> makeRequestTopic "base" "cFCQLYSWNprWkMEWsRcbl1yx" "my.service" "my.method"
 -- Topic {unTopic = "base/grpc/request/cFCQLYSWNprWkMEWsRcbl1yx/my.service/my.method"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeRequestTopic :: Topic -> Topic -> Topic -> Topic -> Topic
 makeRequestTopic base sid svc rpc = base <> "grpc" <> "request" <> sid <> svc <> rpc
 
@@ -74,7 +81,7 @@ makeRequestTopic base sid svc rpc = base <> "grpc" <> "request" <> sid <> svc <>
 -- >>> makeResponseTopic "base.topic" "i1X-Kk7cjUkpeEswPfP9kIid"
 -- Topic {unTopic = "base.topic/grpc/session/i1X-Kk7cjUkpeEswPfP9kIid"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeResponseTopic :: Topic -> Topic -> Topic
 makeResponseTopic base sid = base <> "grpc" <> "session" <> sid
 
@@ -94,7 +101,7 @@ makeResponseTopic base sid = base <> "grpc" <> "session" <> sid
 -- >>> makeControlFilter ("two" <> "level")
 -- Filter {unFilter = "two/levels/grpc/session/+/control"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeControlFilter :: Topic -> Filter
 makeControlFilter base = Topic.toFilter base <> "grpc" <> "session" <> "+" <> "control"
 
@@ -107,6 +114,6 @@ makeControlFilter base = Topic.toFilter base <> "grpc" <> "session" <> "+" <> "c
 -- >>> makeRequestFilter ("two" <> "level")
 -- Filter {unFilter = "two/levels/grpc/request/+/+/+"}
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 makeRequestFilter :: Topic -> Filter
 makeRequestFilter base = Topic.toFilter base <> "grpc" <> "request" <> "+" <> "+" <> "+"

--- a/src/Network/GRPC/MQTT/Types.hs
+++ b/src/Network/GRPC/MQTT/Types.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Types
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Types.hs
+++ b/src/Network/GRPC/MQTT/Types.hs
@@ -1,10 +1,15 @@
--- Copyright (c) 2021 Arista Networks, Inc.
--- Use of this source code is governed by the Apache License 2.0
--- that can be found in the COPYING file.
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
 -- |
+-- Module      :  Network.GRPC.MQTT.Types
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Types
   ( -- * Session Id
     SessionId,
@@ -82,7 +87,7 @@ data MQTTRequest :: GRPCMethodType -> Type -> Type -> Type where
 
 -- | Retrieve a MQTT request's metadata.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 requestMetadata :: MQTTRequest s rqt rsp -> MetadataMap
 requestMetadata (MQTTNormalRequest _ _ ms) = ms
 requestMetadata (MQTTWriterRequest _ ms _) = ms
@@ -91,14 +96,14 @@ requestMetadata (MQTTBiDiRequest _ ms _) = ms
 
 -- | Retrieve a MQTT request's timeout period.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 requestTimeout :: MQTTRequest s rqt rsp -> TimeoutSeconds
 requestTimeout (MQTTNormalRequest _ t _) = t
 requestTimeout (MQTTWriterRequest t _ _) = t
 requestTimeout (MQTTReaderRequest _ t _ _) = t
 requestTimeout (MQTTBiDiRequest t _ _) = t
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Show rqt => Show (MQTTRequest s rqt rsp) where
   show (MQTTNormalRequest x timeout metadata) =
     intercalate " " [show 'MQTTNormalRequest, show x, show timeout, show metadata]

--- a/src/Network/GRPC/MQTT/Wrapping.hs
+++ b/src/Network/GRPC/MQTT/Wrapping.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Network.GRPC.MQTT.Wrapping
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Network/GRPC/MQTT/Wrapping.hs
+++ b/src/Network/GRPC/MQTT/Wrapping.hs
@@ -1,11 +1,15 @@
-{-
-  Copyright (c) 2021 Arista Networks, Inc.
-  Use of this source code is governed by the Apache License 2.0
-  that can be found in the COPYING file.
--}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE RecordWildCards #-}
 
+-- |
+-- Module      :  Network.GRPC.MQTT.Wrapping
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- @since 1.0.0
 module Network.GRPC.MQTT.Wrapping
   ( fromLazyByteString,
     fromRemoteError,

--- a/src/Proto3/Wire/Decode/Extra.hs
+++ b/src/Proto3/Wire/Decode/Extra.hs
@@ -1,11 +1,18 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
 
--- | Extensions to the proto-wire format decoders missing from the proto3-wire
+-- |
+-- Module      :  Proto3.Wire.Decode.Extra
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Extensions to the proto-wire format decoders missing from the proto3-wire
 -- package.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Proto3.Wire.Decode.Extra
   ( -- * Message Parsers
     msgOneField,
@@ -58,7 +65,7 @@ msgOneField recField parse =
 -- * Thrown parse errors are annotated with the field number, field selector,
 --   and parent record.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 oneField :: RecordField -> Parser RawPrimitive a -> Parser RawField a
 oneField recField parse = do
   fieldM <- Decode.one (fmap Just parse) Nothing
@@ -84,13 +91,13 @@ primOneField recField = msgOneField recField . oneField recField
 --   * Thown parse errors are annotated with the field number, field selector,
 --     and parent record.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 primOptField :: RecordField -> Parser RawPrimitive a -> a -> Parser RawMessage a
 primOptField recField parse def = msgOneField recField (Decode.one parse def)
 
 -- | Parses an 'Int' primitive encoded as a fixed-width 64-bit integer.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 sint :: Parser RawPrimitive Int
 sint =
   let parse :: Parser RawPrimitive Int
@@ -109,7 +116,7 @@ sint =
 --   * the name of the 'RecordField' parent record the parsed field is
 --     constructing
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireErrorRecordField :: RecordField -> ParseError -> ParseError
 wireErrorRecordField recField e =
   let issue :: LText
@@ -125,7 +132,7 @@ wireErrorRecordField recField e =
 -- >>> runParser sint (Fixed32Field "bad!")
 -- Left (EmbeddedError "decoding Proto3.Wire.Decode.Extra.sint raised" e)
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 wireErrorLabel :: Name -> ParseError -> ParseError
 wireErrorLabel nm e =
   let issue :: LText
@@ -136,14 +143,14 @@ wireErrorLabel nm e =
 
 -- | Raise a wire-format parse error.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 throwE :: ParseError -> Parser i a
 throwE e = Decode.Parser \_ -> Left e
 {-# INLINE throwE #-}
 
 -- | Catch and handle parse errors by a parser.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 catchE :: Parser i a -> (ParseError -> Parser i a) -> Parser i a
 catchE parse onError =
   Decode.Parser \input ->

--- a/src/Proto3/Wire/Decode/Extra.hs
+++ b/src/Proto3/Wire/Decode/Extra.hs
@@ -4,7 +4,7 @@
 -- |
 -- Module      :  Proto3.Wire.Decode.Extra
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Proto3/Wire/Encode/Extra.hs
+++ b/src/Proto3/Wire/Encode/Extra.hs
@@ -1,9 +1,15 @@
-{-# LANGUAGE ImportQualifiedPost #-}
-
--- | Extensions to the proto-wire format encoders missing from the proto3-wire
+-- |
+-- Module      :  Proto3.Wire.Encode.Extra
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
+--
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Extensions to the proto-wire format encoders missing from the proto3-wire
 -- package.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 module Proto3.Wire.Encode.Extra
   ( -- * Primitive Message Builders
     sint,
@@ -22,7 +28,7 @@ import Relude
 
 -- | Serializes a 'Int' primitive as a fixed-width 64-bit integer.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 sint :: FieldNumber -> Int -> MessageBuilder
 sint field int = do
   let int64 :: Int64

--- a/src/Proto3/Wire/Encode/Extra.hs
+++ b/src/Proto3/Wire/Encode/Extra.hs
@@ -1,7 +1,7 @@
 -- |
 -- Module      :  Proto3.Wire.Encode.Extra
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Proto3/Wire/Types/Extra.hs
+++ b/src/Proto3/Wire/Types/Extra.hs
@@ -1,9 +1,16 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 
--- | Type declarations extending the proto3-wire package.
+-- |
+-- Module      :  Proto3.Wire.Types.Extra
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Type declarations extending the proto3-wire package.
+--
+-- @since 1.0.0
 module Proto3.Wire.Types.Extra
   ( -- * RecordField
     RecordField
@@ -30,7 +37,7 @@ import Text.Show qualified as Show
 -- the record type containing the field, the name of the field, and a compatible
 -- 'FieldNumber' indexing the record field.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 data RecordField = RecordField
   { -- | The name of a record type containing the record field, obtained by a
     -- template haskell quote:
@@ -46,7 +53,7 @@ data RecordField = RecordField
     recFieldNumber :: {-# UNPACK #-} !FieldNumber
   }
 
--- | @since 0.1.0.0
+-- | @since 1.0.0
 instance Show RecordField where
   show (RecordField par sel num) =
     "field #"

--- a/src/Proto3/Wire/Types/Extra.hs
+++ b/src/Proto3/Wire/Types/Extra.hs
@@ -3,7 +3,7 @@
 -- |
 -- Module      :  Proto3.Wire.Types.Extra
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Proto3/Wire/Types/Extra/TH.hs
+++ b/src/Proto3/Wire/Types/Extra/TH.hs
@@ -3,7 +3,7 @@
 
 -- Module      :  Proto3.Wire.Types.Extra.TH
 -- Copyright   :  (c) Arista Networks, 2022-2023
--- License     :  Apache License 2.0, see LICENSE
+-- License     :  Apache License 2.0, see COPYING
 --
 -- Stability   :  stable
 -- Portability :  non-portable (GHC extensions)

--- a/src/Proto3/Wire/Types/Extra/TH.hs
+++ b/src/Proto3/Wire/Types/Extra/TH.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE ImplicitPrelude #-}
 
--- | Template haskell extensions to type exported by the proto3-wire package.
+-- Module      :  Proto3.Wire.Types.Extra.TH
+-- Copyright   :  (c) Arista Networks, 2022-2023
+-- License     :  Apache License 2.0, see LICENSE
 --
--- @since 0.1.0.0
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- Template haskell extensions to type exported by the proto3-wire package.
+--
+-- @since 1.0.0
 module Proto3.Wire.Types.Extra.TH
   ( -- * Template Haskell Extensions
     liftFieldNumber,
@@ -26,7 +33,7 @@ import Proto3.Wire.Types.Extra (RecordField (RecordField))
 
 -- | Lifts a 'FieldNumber' type into a quoted expression.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 liftFieldNumber :: FieldNumber -> Q Exp
 liftFieldNumber (FieldNumber x) = do
   litE <- lift x
@@ -36,7 +43,7 @@ liftFieldNumber (FieldNumber x) = do
 
 -- | Lifts a 'RecordField' type into a quoted expression.
 --
--- @since 0.1.0.0
+-- @since 1.0.0
 liftRecordField :: RecordField -> Q Exp
 liftRecordField (RecordField par sel num) = do
   parE <- lift par

--- a/test/Test/Network/GRPC/HighLevel/Extra.hs
+++ b/test/Test/Network/GRPC/HighLevel/Extra.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Network.GRPC.HighLevel.Extra
   ( -- * Test Tree

--- a/test/Test/Network/GRPC/HighLevel/Extra/Gen.hs
+++ b/test/Test/Network/GRPC/HighLevel/Extra/Gen.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 -- | Generators for @grpc-haskell@ types.
 module Test.Network.GRPC.HighLevel.Extra.Gen

--- a/test/Test/Network/GRPC/MQTT/Message/Packet.hs
+++ b/test/Test/Network/GRPC/MQTT/Message/Packet.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Network.GRPC.MQTT.Message.Packet
   ( -- * Test Tree

--- a/test/Test/Network/GRPC/MQTT/Message/Request.hs
+++ b/test/Test/Network/GRPC/MQTT/Message/Request.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Network.GRPC.MQTT.Message.Request
   ( -- * Test Tree

--- a/test/Test/Network/GRPC/MQTT/Message/Stream.hs
+++ b/test/Test/Network/GRPC/MQTT/Message/Stream.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Network.GRPC.MQTT.Message.Stream
   ( -- * Test Tree

--- a/test/Test/Proto/Service.hs
+++ b/test/Test/Proto/Service.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE TypeApplications #-}
 

--- a/test/Test/Service.hs
+++ b/test/Test/Service.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeApplications #-}
 
 -- |

--- a/test/Test/Suite/Config.hs
+++ b/test/Test/Suite/Config.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Test.Suite.Config

--- a/test/Test/Suite/Fixture.hs
+++ b/test/Test/Suite/Fixture.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Suite.Fixture
   ( Fixture (Fixture, unFixture),

--- a/test/Test/Suite/Wire.hs
+++ b/test/Test/Suite/Wire.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ImportQualifiedPost #-}
 
 module Test.Suite.Wire
   ( -- * Test Combinators


### PR DESCRIPTION
Adds Haddock module description documentation to all `grpc-mqtt` library modules. I also removed redundant `{-# LANGUAGE ImportQualifiedPost #-` pragmas since we enabled the  `ImportQualifiedPost` extension by default.