### PR TITLE
In CI, pin nix version due to regression in 2.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v17
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
 
       - name: Set up Cachix
         uses: cachix/cachix-action@v10


### PR DESCRIPTION
https://github.com/cachix/cachix-action/issues/137