### PR TITLE
Remove mosquitto bridge configuration

### DIFF
--- a/test-files/mqtt-broker.conf
+++ b/test-files/mqtt-broker.conf
@@ -1,12 +1,5 @@
 listener 1883 localhost
-connection test_broker
-address    localhost
 protocol   mqtt
-
-cleansession    true
 allow_anonymous true
-
-topic "testMachine/testclient/grpc/session/"
-topic "testMachine/testclient/grpc/request/"
 
 pid_file test-files/mqtt-broker.pid


### PR DESCRIPTION
These options are for using mosquitto as a bridge between multiple MQTT brokers, which doesn't seem applicable here. I don't think it was causing any issues other than adding some noise the the test logs.