### PR TITLE
Update `grpc-haskell` and `grpc-haskell-core` pins to revision `d20c20d`

### DIFF
--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -7,7 +7,7 @@ mkDerivation {
   pname = "grpc-haskell-core";
   version = "0.5.0";
   src = fetchgit {
-    url = "git@github.com:awakesecurity/gRPC-haskell.git";
+    url = "https://github.com/awakesecurity/gRPC-haskell.git";
     sha256 = "17wjm9lbyzhm98g4g36v3jlnr00s5yzilrv90p12mqgn3ffhkg28";
     rev = "d20c20d63c170b5eaf5725f03f7b7060352af402";
     fetchSubmodules = true;

--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -7,9 +7,9 @@ mkDerivation {
   pname = "grpc-haskell-core";
   version = "0.5.0";
   src = fetchgit {
-    url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "0sh553lvz3vi1mq65jicy6n3ga4zcifabvapi217kpivxjsa18g6";
-    rev = "414ae8e6612e8e28d2bcfb6e201303f5fc031e5a";
+    url = "git@github.com:awakesecurity/gRPC-haskell.git";
+    sha256 = "17wjm9lbyzhm98g4g36v3jlnr00s5yzilrv90p12mqgn3ffhkg28";
+    rev = "d20c20d63c170b5eaf5725f03f7b7060352af402";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -8,7 +8,7 @@ mkDerivation {
   pname = "grpc-haskell";
   version = "0.3.0";
   src = fetchgit {
-    url = "git@github.com:awakesecurity/gRPC-haskell.git";
+    url = "https://github.com/awakesecurity/gRPC-haskell.git";
     sha256 = "17wjm9lbyzhm98g4g36v3jlnr00s5yzilrv90p12mqgn3ffhkg28";
     rev = "d20c20d63c170b5eaf5725f03f7b7060352af402";
     fetchSubmodules = true;

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -8,9 +8,9 @@ mkDerivation {
   pname = "grpc-haskell";
   version = "0.3.0";
   src = fetchgit {
-    url = "https://github.com/awakesecurity/gRPC-haskell";
-    sha256 = "0sh553lvz3vi1mq65jicy6n3ga4zcifabvapi217kpivxjsa18g6";
-    rev = "414ae8e6612e8e28d2bcfb6e201303f5fc031e5a";
+    url = "git@github.com:awakesecurity/gRPC-haskell.git";
+    sha256 = "17wjm9lbyzhm98g4g36v3jlnr00s5yzilrv90p12mqgn3ffhkg28";
+    rev = "d20c20d63c170b5eaf5725f03f7b7060352af402";
     fetchSubmodules = true;
   };
   isLibrary = true;


### PR DESCRIPTION
This PR updates the pinned `grpc-haskell` and `grpc-haskell` revisions to https://github.com/awakesecurity/gRPC-haskell/commit/d20c20d63c170b5eaf5725f03f7b7060352af402. This revision includes the fix for a initial metadata memory leak in the C core of [gRPC-haskell](https://github.com/awakesecurity/gRPC-haskell). 