### PR TITLE
Delay sending of first heartbeat message

### DIFF
--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -325,7 +325,7 @@ withControlSignals publishControlMsg =
     withMQTTHeartbeat :: IO a -> IO a
     withMQTTHeartbeat action =
       Async.withAsync
-        (forever (publishControlMsg AuxControlAlive >> sleep heartbeatPeriodSeconds))
+        (forever (sleep heartbeatPeriodSeconds >> publishControlMsg AuxControlAlive))
         (const action)
 
     sendTerminateOnException :: IO a -> IO a


### PR DESCRIPTION
Currently, the first heartbeat message comes out immediately after sending the request. Sometimes it can even be delivered before the request is received.

There is plenty of buffer for the heartbeat message to delay one cycle before sending. This has the additional benefit of often not needing to send a heartbeat at all for quick requests.