### PR TITLE
Support supplying TLS credentials in test-suite

### DIFF
--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -187,6 +187,7 @@ test-suite test
 
   build-depends:
     , connection
+    , containers
     , data-default
     , grpc-mqtt
     , hedgehog
@@ -195,4 +196,4 @@ test-suite test
     , tasty-hunit
     , tls
     , uuid
-    , containers
+    , x509-store

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -61,9 +61,13 @@ testOptions :: [OptionDescription]
 testOptions =
   [ Option (Proxy @NumThreads)
   , Option (Proxy @(TestOption "broker-port" Port))
+  , Option (Proxy @(TestOption "broker-host" Host))
   , Option (Proxy @(TestOption "server-port" Port))
   , Option (Proxy @(TestOption "server-host" Host))
   , Option (Proxy @(TestOption "base-topic" Topic))
   , Option (Proxy @(TestOption "client-id" String))
   , Option (Proxy @(TestOption "remote-id" String))
+  , Option (Proxy @(TestOption "certificate-path" (Maybe FilePath)))
+  , Option (Proxy @(TestOption "private-key-path" (Maybe FilePath)))
+  , Option (Proxy @(TestOption "certificate-store-path" (Maybe FilePath)))
   ]

--- a/test/Test/Suite/Config.hs
+++ b/test/Test/Suite/Config.hs
@@ -49,16 +49,18 @@ import Data.Default (def)
 
 import Data.ByteString.Char8 qualified as ByteString.Char8
 
+import Data.X509.CertificateStore (readCertificateStore)
+
 import GHC.TypeLits (Symbol)
 
 import Network.Connection (TLSSettings (TLSSettings))
 
-import Network.GRPC.LowLevel.Call (Endpoint (..))
 import Network.GRPC.HighLevel.Client (ClientConfig, Host, Port)
 import Network.GRPC.HighLevel.Client qualified as GRPC.Client
 import Network.GRPC.HighLevel.Generated (Host (..), Port (..), ServiceOptions)
 import Network.GRPC.HighLevel.Generated qualified as GRPC.Generated
-import Network.GRPC.Unsafe.ChannelArgs (Arg(..))
+import Network.GRPC.LowLevel.Call (Endpoint (..))
+import Network.GRPC.Unsafe.ChannelArgs (Arg (..))
 
 import Network.MQTT.Topic (Topic)
 
@@ -66,6 +68,8 @@ import Network.TLS (defaultParamsClient)
 import Network.TLS qualified as TLS
 import Network.TLS.Extra.Cipher (ciphersuite_default)
 
+import GHC.IO (throwIO)
+import GHC.IO.Exception (userError)
 import Relude
 
 --------------------------------------------------------------------------------
@@ -77,42 +81,53 @@ import Network.GRPC.MQTT.Core qualified as GRPC.MQTT
 
 data TestConfig = TestConfig
   { testConfigBrokerPort :: Port
+  , testConfigBrokerHost :: Host
   , testConfigServerPort :: Port
   , testConfigServerHost :: Host
   , testConfigBaseTopic :: Topic
   , testConfigClientId :: String
   , testConfigRemoteId :: String
+  , testConfigCertificatePath :: Maybe FilePath
+  , testConfigPrivateKeyPath :: Maybe FilePath
+  , testConfigCertStorePath :: Maybe FilePath
   }
   deriving (Eq, Show)
 
 withTestConfig :: (TestConfig -> TestTree) -> TestTree
 withTestConfig = runCont do
   brokerPort <- cont (askTestOption @"broker-port")
+  brokerHost <- cont (askTestOption @"broker-host")
   serverPort <- cont (askTestOption @"server-port")
   serverHost <- cont (askTestOption @"server-host")
   baseTopic <- cont (askTestOption @"base-topic")
   clientId <- cont (askTestOption @"client-id")
   remoteId <- cont (askTestOption @"remote-id")
-  let config :: TestConfig
-      config =
-        TestConfig
-          { testConfigBrokerPort = brokerPort
-          , testConfigServerPort = serverPort
-          , testConfigServerHost = serverHost
-          , testConfigBaseTopic = baseTopic
-          , testConfigClientId = clientId
-          , testConfigRemoteId = remoteId
-          }
-   in pure config
+  certificatePath <- cont (askTestOption @"certificate-path")
+  privateKeyPath <- cont (askTestOption @"private-key-path")
+  certStorePath <- cont (askTestOption @"certificate-store-path")
+  pure $
+    TestConfig
+      { testConfigBrokerPort = brokerPort
+      , testConfigBrokerHost = brokerHost
+      , testConfigServerPort = serverPort
+      , testConfigServerHost = serverHost
+      , testConfigBaseTopic = baseTopic
+      , testConfigClientId = clientId
+      , testConfigRemoteId = remoteId
+      , testConfigCertificatePath = certificatePath
+      , testConfigPrivateKeyPath = privateKeyPath
+      , testConfigCertStorePath = certStorePath
+      }
 
 askServiceOptions :: MonadReader TestConfig m => m ServiceOptions
 askServiceOptions = do
   port <- asks testConfigServerPort
-  pure GRPC.Generated.defaultServiceOptions
-    { GRPC.Generated.serverPort = port
-    , GRPC.Generated.serverMaxReceiveMessageLength = Just 268435456
-    , GRPC.Generated.serverMaxMetadataSize = Just 100_000_000_000_000
-    }
+  pure
+    GRPC.Generated.defaultServiceOptions
+      { GRPC.Generated.serverPort = port
+      , GRPC.Generated.serverMaxReceiveMessageLength = Just 268435456
+      , GRPC.Generated.serverMaxMetadataSize = Just 100_000_000_000_000
+      }
 
 askConfigClientGRPC :: MonadReader TestConfig m => m ClientConfig
 askConfigClientGRPC = do
@@ -123,45 +138,73 @@ askConfigClientGRPC = do
         GRPC.Client.ClientConfig
           { GRPC.Client.clientServerEndpoint = Endpoint $ host <> ":" <> show port
           , GRPC.Client.clientArgs =
-              [ MaxReceiveMessageLength 268435456 ]
+              [MaxReceiveMessageLength 268435456]
           , GRPC.Client.clientSSLConfig = Nothing
           , GRPC.Client.clientAuthority = Nothing
           }
    in pure config
 
-askConfigMQTT :: MonadReader TestConfig m => m MQTTGRPCConfig
+askConfigMQTT :: (MonadReader TestConfig m, MonadIO m) => m MQTTGRPCConfig
 askConfigMQTT = do
-  GRPC.Client.Host host <- asks testConfigServerHost
+  GRPC.Client.Host host <- asks testConfigBrokerHost
   GRPC.Client.Port port <- asks testConfigBrokerPort
-  let config :: MQTTGRPCConfig
-      config =
-        GRPC.MQTT.defaultMGConfig
-          { GRPC.MQTT._hostname = ByteString.Char8.unpack host
-          , GRPC.MQTT._port = port
-          , GRPC.MQTT._tlsSettings =
-              TLSSettings
-                (defaultParamsClient "localhost" "")
-                  { TLS.clientSupported = def{TLS.supportedCiphers = ciphersuite_default}
-                  }
-          }
-   in pure config
 
-askClientConfigMQTT :: MonadReader TestConfig m => m MQTTGRPCConfig
+  mcertFilepath <- asks testConfigCertificatePath
+  mprivKeyFilepath <- asks testConfigPrivateKeyPath
+  mcertStoreFilepath <- asks testConfigCertStorePath
+
+  (tlsSettings, useTLS) <- case (mcertFilepath, mprivKeyFilepath, mcertStoreFilepath) of
+    (Just certFilepath, Just privKeyFilepath, Just certStoreFilepath) -> do
+      cred <-
+        liftIO $
+          TLS.credentialLoadX509 certFilepath privKeyFilepath >>= \case
+            Right c -> pure c
+            Left err -> throwIO $ userError ("Failed to load TLS credentials: " <> show err)
+      certStore <-
+        liftIO $
+          readCertificateStore certStoreFilepath >>= \case
+            Just cs -> pure cs
+            Nothing -> throwIO $ userError "Failed to read cert store"
+
+      let settings =
+            TLSSettings
+              (defaultParamsClient (decodeUtf8 host) "")
+                { TLS.clientSupported = def{TLS.supportedCiphers = ciphersuite_default}
+                , TLS.clientShared =
+                    def
+                      { TLS.sharedCredentials = TLS.Credentials [cred]
+                      , TLS.sharedCAStore = certStore
+                      }
+                , TLS.clientHooks = def{TLS.onCertificateRequest = \_ -> return (Just cred)}
+                }
+      pure (settings, True)
+    _ -> pure (def, False)
+
+  pure
+    GRPC.MQTT.defaultMGConfig
+      { GRPC.MQTT._hostname = ByteString.Char8.unpack host
+      , GRPC.MQTT._port = port
+      , GRPC.MQTT._tlsSettings = tlsSettings
+      , GRPC.MQTT.useTLS = useTLS
+      }
+
+askClientConfigMQTT :: (MonadReader TestConfig m, MonadIO m) => m MQTTGRPCConfig
 askClientConfigMQTT = do
   clientid <- asks testConfigClientId
   config <- askConfigMQTT
-  pure config 
-    { GRPC.MQTT._connID = clientid
-    }
+  pure
+    config
+      { GRPC.MQTT._connID = clientid
+      }
 
-
-askRemoteConfigMQTT :: MonadReader TestConfig m => m MQTTGRPCConfig
+askRemoteConfigMQTT :: (MonadReader TestConfig m, MonadIO m) => m MQTTGRPCConfig
 askRemoteConfigMQTT = do
   remoteid <- asks testConfigRemoteId
   config <- askConfigMQTT
-  pure config 
-    { GRPC.MQTT._connID = remoteid
-    }
+  pure
+    config
+      { GRPC.MQTT._connID = remoteid
+      }
 
 --------------------------------------------------------------------------------
 
@@ -197,6 +240,14 @@ instance IsOption (TestOption "broker-port" Port) where
 
   parseValue = fmap (TestOption @"broker-port") . parsePort
 
+instance IsOption (TestOption "broker-host" Host) where
+  optionName = "broker-host"
+  optionHelp = "The hostname used by the MQTT broker."
+
+  defaultValue = TestOption @"broker-host" "localhost"
+
+  parseValue = Just . TestOption @"broker-host" . GRPC.Client.Host . ByteString.Char8.pack
+
 instance IsOption (TestOption "server-port" Port) where
   optionName = "server-port"
   optionHelp = "The port used by the test gRPC services."
@@ -207,7 +258,7 @@ instance IsOption (TestOption "server-port" Port) where
 
 instance IsOption (TestOption "server-host" Host) where
   optionName = "server-host"
-  optionHelp = "The hostname used by the MQTT broker and test gRPC services."
+  optionHelp = "The hostname used by the test gRPC services."
 
   defaultValue = TestOption @"server-host" "localhost"
 
@@ -236,3 +287,27 @@ instance IsOption (TestOption "remote-id" String) where
   defaultValue = TestOption @"remote-id" "Test.Adaptor"
 
   parseValue = Just . TestOption @"remote-id" . fromString
+
+instance IsOption (TestOption "certificate-path" (Maybe FilePath)) where
+  optionName = "certificate-path"
+  optionHelp = "Path to client TLS certificate for MQTTS."
+
+  defaultValue = TestOption @"certificate-path" Nothing
+
+  parseValue = Just . TestOption @"certificate-path" . Just . fromString
+
+instance IsOption (TestOption "private-key-path" (Maybe FilePath)) where
+  optionName = "private-key-path"
+  optionHelp = "Path to client TLS private key file for MQTTS."
+
+  defaultValue = TestOption @"private-key-path" Nothing
+
+  parseValue = Just . TestOption @"private-key-path" . Just . fromString
+
+instance IsOption (TestOption "certificate-store-path" (Maybe FilePath)) where
+  optionName = "certificate-store-path"
+  optionHelp = "Path to SSL certificate store for MQTTS."
+
+  defaultValue = TestOption @"certificate-store-path" Nothing
+
+  parseValue = Just . TestOption @"certificate-store-path" . Just . fromString


### PR DESCRIPTION
This allows running the test suite with other MQTT brokers (e.g. AWS)