### PR TITLE
Update `MQTTGRPCConfig` to work with upstream `MQTTConfig` changes in `net-mqtt-0.8.3.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,3 @@
-with-compiler: ghc-8.10.4
-
 jobs: $ncpus
 
 packages: 

--- a/flake.lock
+++ b/flake.lock
@@ -37,16 +37,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1622516815,
-        "narHash": "sha256-ZjBd81a6J3TwtlBr3rHsZspYUwT9OdhDk+a/SgSEf7I=",
+        "lastModified": 1685566663,
+        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7e9b0dff974c89e070da1ad85713ff3c20b0ca97",
+        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "21.05",
+        "ref": "23.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -56,7 +56,7 @@ common common
     , grpc-haskell         >= 0.3.0    && < 0.4
     , grpc-haskell-core    >= 0.5.0    && < 0.6
     , mtl                  >= 2.2.2    && < 2.3
-    , net-mqtt             >= 0.8.2    && < 0.9
+    , net-mqtt             >= 0.8.3    && < 0.9
     , proto3-suite         >= 0.5.2    && < 0.8
     , proto3-wire          >= 1.2.2    && < 1.5
     , relude               >= 0.7.0    && < 1.3

--- a/nix/packages/net-mqtt.nix
+++ b/nix/packages/net-mqtt.nix
@@ -6,8 +6,8 @@
 }:
 mkDerivation {
   pname = "net-mqtt";
-  version = "0.8.2.5";
-  sha256 = "3d41045cbc9b1adbaccab90ee9a4bc3e751fb41d50ea2fa65f7024231f7cde4c";
+  version = "0.8.3.0";
+  sha256 = "d421593781a7360a50f3864eec9ffe67f8dbc2af4429703b7a730f91bb5ec20b";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -65,7 +65,9 @@ import Network.MQTT.Client
         _port,
         _protocol,
         _tlsSettings,
-        _username
+        _username,
+        _pingPeriod,
+        _pingPatience
       ),
     MQTTException (MQTTException),
     MessageCallback (NoCallback),
@@ -115,6 +117,8 @@ data MQTTGRPCConfig = MQTTGRPCConfig
   , _password :: Maybe String
   , _connectTimeout :: Int
   , _tlsSettings :: TLSSettings
+  , _pingPeriod :: Int
+  , _pingPatience :: Int
   }
 
 -- | The default 'MQTTGRPCConfig'.
@@ -139,6 +143,8 @@ defaultMGConfig =
     , _password = Nothing
     , _connectTimeout = 180000000
     , _tlsSettings = TLSSettingsSimple False False False
+    , _pingPeriod = 30000000
+    , _pingPatience = 90000000
     }
 
 -- | Project 'MQTTConfig' from 'MQTTGRPCConfig'


### PR DESCRIPTION
This change adds two new fields to the `MQTTGRPCConfig` data type:

- `_pingPeriod`; and,
- `_pingPatience`