### PR TITLE
Fix import of `simpleProgram` with Cabal 3.10

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -6,9 +6,9 @@
 import Distribution.Simple
          (UserHooks(..), defaultMainWithHooks, simpleUserHooks)
 import Distribution.Simple.PreProcess (PreProcessor(..))
-import Distribution.Simple.Program (runProgram)
+import Distribution.Simple.Program (runProgram, simpleProgram)
 import Distribution.Simple.Program.Db (requireProgram)
-import Distribution.Simple.Program.Types (Program(..), simpleProgram)
+import Distribution.Simple.Program.Types (Program(..))
 import Distribution.Simple.Utils (info)
 import Distribution.Types.BuildInfo (BuildInfo)
 import Distribution.Types.LocalBuildInfo (LocalBuildInfo(..))


### PR DESCRIPTION
It used to live in `Distribution.Simple.Program.Types` but in Cabal 3.10 the implementation was moved one module higher.
Since it used to be reexported there in older releases, it should be backwards compatible