### PR TITLE
Support GHC 9.8, upgrade nixpkgs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        ghc: [ghc96, ghc98]
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -27,4 +31,4 @@ jobs:
           name: awakesecurity
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
-      - run: nix build --print-build-logs
+      - run: nix build --print-build-logs .#with-${{ matrix.ghc }}

--- a/flake.lock
+++ b/flake.lock
@@ -40,16 +40,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731603435,
-        "narHash": "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=",
+        "lastModified": 1748026580,
+        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b27c1239e5c421a2bbc2c65d52e4a6fbf2ff296",
+        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "24.11",
+        "ref": "25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -16,14 +16,14 @@
         };
 
         ghcVersions = rec {
-          default = ghc96;
+          default = with-ghc96;
 
-          ghc96 = import nixpkgs {
+          with-ghc96 = import nixpkgs {
             inherit system;
             overlays = [ (haskellOverlay "ghc96") ];
           };
 
-          ghc98 = import nixpkgs {
+          with-ghc98 = import nixpkgs {
             inherit system;
             overlays = [ (haskellOverlay "ghc98") ];
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/25.05";
     flake-utils.url = "github:numtide/flake-utils";
     gitignore = {
       url = "github:hercules-ci/gitignore.nix";

--- a/flake.nix
+++ b/flake.nix
@@ -11,18 +11,25 @@
   outputs = { self, nixpkgs, flake-utils, gitignore }:
     flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (system:
       let
-        ghc = "ghc96";
-
-        haskellOverlay = import nix/overlays/haskell.nix {
+        haskellOverlay = ghc: import nix/overlays/haskell.nix {
           inherit gitignore ghc;
         };
 
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ haskellOverlay ];
+        ghcVersions = rec {
+          default = ghc96;
+
+          ghc96 = import nixpkgs {
+            inherit system;
+            overlays = [ (haskellOverlay "ghc96") ];
+          };
+
+          ghc98 = import nixpkgs {
+            inherit system;
+            overlays = [ (haskellOverlay "ghc98") ];
+          };
         };
       in {
-        packages.default = pkgs.haskell.packages.${ghc}.grpc-mqtt;
-        devShells.default = pkgs.grpc-mqtt-dev-shell;
+        packages = builtins.mapAttrs (_: pkgs: pkgs.grpc-mqtt) ghcVersions;
+        devShells = builtins.mapAttrs (_: pkgs: pkgs.grpc-mqtt-dev-shell) ghcVersions;
       });
 }

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -62,7 +62,7 @@ common common
     , proto3-wire          >= 1.2.2    && < 1.5
     , relude               >= 0.7.0    && < 1.3
     , stm                  >= 2.5.0    && < 2.6
-    , text                 >= 0.2      && < 2.3
+    , text                 >= 0.2      && < 2.2
     , time                 >= 1.9.3    && < 1.13
     , turtle               >= 1.6.1    && < 1.7.0
     , vector               >= 0.11     && < 0.14
@@ -133,7 +133,7 @@ library
     , nonce                >= 1.0.7   && < 1.1
     , pqueue               >= 1.4.1.3 && < 1.6
     , safe-exceptions      >= 0.1.7   && < 0.2
-    , template-haskell     >= 2.16.0  && < 2.22
+    , template-haskell     >= 2.16.0  && < 2.23
     , unliftio             >= 0.2.15  && < 0.3
     , unliftio-core        >= 0.2.0   && < 0.3
     , unordered-containers >= 0.2.13  && < 0.3

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -15,8 +15,8 @@ extra-source-files:
   README.md
 
 tested-with:
-  GHC == 9.4.8
-  GHC == 9.6.6
+  GHC == 9.6.7
+  GHC == 9.8.4
 
 custom-setup
   setup-depends: base, Cabal, filepath

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -128,6 +128,7 @@ library
   build-depends:
     , conduit-extra        >= 1.3.5   && < 1.4
     , crypton-connection   >= 0.3.1   && < 0.5
+    , data-default         >= 0.7     && < 0.9
     , network-conduit-tls  >= 1.3.2   && < 1.5
     , nonce                >= 1.0.7   && < 1.1
     , pqueue               >= 1.4.1.3 && < 1.6

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -50,10 +50,10 @@ common common
 
   build-depends:
     , async                >= 2.2.3    && < 2.3
-    , base                 >= 4.14     && < 4.19
-    , bytestring           >= 0.10.6.0 && < 0.12.0
+    , base                 >= 4.14     && < 4.20
+    , bytestring           >= 0.10.6.0 && < 0.13
     , containers           >= 0.5      && < 0.7
-    , deepseq              == 1.4.*
+    , deepseq              >= 1.4      && < 1.6
     , grpc-haskell         >= 0.3.0    && < 0.5
     , grpc-haskell-core    >= 0.5.0    && < 0.7
     , mtl                  >= 2.2.2    && < 2.4
@@ -62,7 +62,7 @@ common common
     , proto3-wire          >= 1.2.2    && < 1.5
     , relude               >= 0.7.0    && < 1.3
     , stm                  >= 2.5.0    && < 2.6
-    , text                 >= 0.2      && < 2.2
+    , text                 >= 0.2      && < 2.3
     , time                 >= 1.9.3    && < 1.13
     , turtle               >= 1.6.1    && < 1.7.0
     , vector               >= 0.11     && < 0.14
@@ -133,7 +133,7 @@ library
     , nonce                >= 1.0.7   && < 1.1
     , pqueue               >= 1.4.1.3 && < 1.6
     , safe-exceptions      >= 0.1.7   && < 0.2
-    , template-haskell     >= 2.16.0  && < 2.21
+    , template-haskell     >= 2.16.0  && < 2.22
     , unliftio             >= 0.2.15  && < 0.3
     , unliftio-core        >= 0.2.0   && < 0.3
     , unordered-containers >= 0.2.13  && < 0.3

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -31,6 +31,8 @@ final: prev: {
     };
   };
 
+  grpc-mqtt = final.haskell.packages.${ghc}.grpc-mqtt;
+
   grpc-mqtt-dev-shell =
     let
       hsPkgs = final.haskell.packages.${ghc};

--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.6.1";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "0y7b768sldrny19acdpwrs51npk354k2cf9mrhdjm856941im229";
-    rev = "ba7197e1a74d8a0048f53a3b9d46b8235de6838f";
+    sha256 = "1asxvx19armyqbfl19licxg8gd1c7r27vbkr81hymm41jwlnnrk8";
+    rev = "f6d68ec04756a6427fd207573f581870f12bae93";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.6.1";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "1asxvx19armyqbfl19licxg8gd1c7r27vbkr81hymm41jwlnnrk8";
-    rev = "f6d68ec04756a6427fd207573f581870f12bae93";
+    sha256 = "1j21cnhd1wbf0fn8vlrv7g6m10d1i7x31a9m1x4srwbqlc2ry51z";
+    rev = "ddf02163fa82f1f287351336fbe9e174b6e5b9db";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "1asxvx19armyqbfl19licxg8gd1c7r27vbkr81hymm41jwlnnrk8";
-    rev = "f6d68ec04756a6427fd207573f581870f12bae93";
+    sha256 = "1j21cnhd1wbf0fn8vlrv7g6m10d1i7x31a9m1x4srwbqlc2ry51z";
+    rev = "ddf02163fa82f1f287351336fbe9e174b6e5b9db";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "0y7b768sldrny19acdpwrs51npk354k2cf9mrhdjm856941im229";
-    rev = "ba7197e1a74d8a0048f53a3b9d46b8235de6838f";
+    sha256 = "1asxvx19armyqbfl19licxg8gd1c7r27vbkr81hymm41jwlnnrk8";
+    rev = "f6d68ec04756a6427fd207573f581870f12bae93";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/src/Network/GRPC/MQTT/Core.hs
+++ b/src/Network/GRPC/MQTT/Core.hs
@@ -42,12 +42,14 @@ import Data.Conduit.Network.TLS
     tlsClientConfig,
   )
 
+import Data.Default (def)
+
 import Data.Time.Clock (NominalDiffTime)
 
 import Data.ByteString.Char8 qualified as ByteString.Char8
 import Data.List qualified as L
 
-import Network.Connection (ProxySettings, TLSSettings (TLSSettingsSimple))
+import Network.Connection (ProxySettings, TLSSettings)
 
 import Network.MQTT.Client
   ( MQTTClient,
@@ -142,7 +144,7 @@ defaultMGConfig =
     , _username = Nothing
     , _password = Nothing
     , _connectTimeout = 180000000
-    , _tlsSettings = TLSSettingsSimple False False False
+    , _tlsSettings = def
     , _pingPeriod = 30000000
     , _pingPatience = 90000000
     }


### PR DESCRIPTION
Bumps nixpkgs to 25.05 (needed newer `net-mqtt`).
Support building with different GHCs (in flake and also in CI)
Replaced `TLSSettingsSimple` with `Data.Default`, which should prevent future breakages on changes to `TLSSettingsSimple` constructor (see https://github.com/kazu-yamamoto/crypton-connection/pull/3)

~Note: `grpc-haskell*` packages are on an unmerged PR. Keeping this as draft until it merges. https://github.com/awakesecurity/gRPC-haskell/pull/170~