### PR TITLE
Add support for GHC 9.10

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: [ghc96, ghc98]
+        ghc: [ghc96, ghc98, ghc910]
 
     steps:
       - name: Checkout

--- a/Setup.hs
+++ b/Setup.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 
+import Distribution.Compat.Prelude (fromString)
 import Distribution.Simple
          (UserHooks(..), defaultMainWithHooks, simpleUserHooks)
 import Distribution.Simple.PreProcess (PreProcessor(..))
@@ -26,7 +27,7 @@ main = defaultMainWithHooks customHooks
 customHooks :: UserHooks
 customHooks = simpleUserHooks
   { hookedPreProcessors =
-      ( "proto", ppProto ) : hookedPreProcessors simpleUserHooks
+      ( fromString "proto", ppProto ) : hookedPreProcessors simpleUserHooks
   }
 
 -- | Converts a MyModule.proto to MyModule.hs using compile-proto-file,

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,11 @@
             inherit system;
             overlays = [ (haskellOverlay "ghc98") ];
           };
+          
+          with-ghc910 = import nixpkgs {
+            inherit system;
+            overlays = [ (haskellOverlay "ghc910") ];
+          };
         };
       in {
         packages = builtins.mapAttrs (_: pkgs: pkgs.grpc-mqtt) ghcVersions;

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -17,6 +17,7 @@ extra-source-files:
 tested-with:
   GHC == 9.6.7
   GHC == 9.8.4
+  GHC == 9.10.1
 
 custom-setup
   setup-depends: base, Cabal, filepath
@@ -50,9 +51,9 @@ common common
 
   build-depends:
     , async                >= 2.2.3    && < 2.3
-    , base                 >= 4.14     && < 4.20
+    , base                 >= 4.14     && < 4.21
     , bytestring           >= 0.10.6.0 && < 0.13
-    , containers           >= 0.5      && < 0.7
+    , containers           >= 0.5      && < 0.8
     , deepseq              >= 1.4      && < 1.6
     , grpc-haskell         >= 0.3.0    && < 0.5
     , grpc-haskell-core    >= 0.5.0    && < 0.7

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -6,10 +6,13 @@ final: prev: {
       "${ghc}" = prev.haskell.packages."${ghc}".override (old: {
         overrides = prev.lib.fold prev.lib.composeExtensions (old.overrides or (_: _: { })) [
           (hfinal: hprev: {
+            # Too tight bounds to support GHC 9.10
+            # See: https://github.com/dustin/mqtt-hs/issues/52
+            net-mqtt = final.haskell.lib.doJailbreak hprev.net-mqtt;
+
             proto3-wire = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-wire.nix  { });
             proto3-suite = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-suite.nix { });
-          })
-          (hfinal: _: {
+
             grpc-haskell = final.haskell.lib.doJailbreak
               (final.haskell.lib.dontCheck (hfinal.callPackage ../packages/grpc-haskell.nix { }));
             grpc-haskell-core = final.haskell.lib.doJailbreak


### PR DESCRIPTION
The only broken thing was in cabal, where preprocessors now accept `Suffix` instead of `String` type
see: https://hackage.haskell.org/package/Cabal-3.12.1.0/docs/Distribution-Simple-PreProcess.html#t:Suffix