### PR TITLE
 Add support for GHC 9.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,15 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v17
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+        uses: cachix/install-nix-action@v31
 
       - name: Set up Cachix
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v16
         with:
           name: awakesecurity
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: [ghc96, ghc98, ghc910]
+        ghc: [ghc96, ghc98, ghc910, ghc912]
 
     steps:
       - name: Checkout

--- a/flake.lock
+++ b/flake.lock
@@ -25,11 +25,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
@@ -40,16 +40,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748026580,
-        "narHash": "sha256-rWtXrcIzU5wm/C8F9LWvUfBGu5U5E7cFzPYT1pHIJaQ=",
+        "lastModified": 1764521362,
+        "narHash": "sha256-M101xMtWdF1eSD0xhiR8nG8CXRlHmv6V+VoY65Smwf4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "11cb3517b3af6af300dd6c055aeda73c9bf52c48",
+        "rev": "871b9fd269ff6246794583ce4ee1031e1da71895",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "25.05",
+        "ref": "25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
             inherit system;
             overlays = [ (haskellOverlay "ghc910") ];
           };
+
+          with-ghc912 = import nixpkgs {
+            inherit system;
+            overlays = [ (haskellOverlay "ghc912") ];
+          };
         };
       in {
         packages = builtins.mapAttrs (_: pkgs: pkgs.grpc-mqtt) ghcVersions;

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/25.11";
     flake-utils.url = "github:numtide/flake-utils";
     gitignore = {
       url = "github:hercules-ci/gitignore.nix";

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -51,7 +51,7 @@ common common
 
   build-depends:
     , async                >= 2.2.3    && < 2.3
-    , base                 >= 4.14     && < 4.21
+    , base                 >= 4.14     && < 4.22
     , bytestring           >= 0.10.6.0 && < 0.13
     , containers           >= 0.5      && < 0.8
     , deepseq              >= 1.4      && < 1.6
@@ -64,7 +64,7 @@ common common
     , relude               >= 0.7.0    && < 1.3
     , stm                  >= 2.5.0    && < 2.6
     , text                 >= 0.2      && < 2.2
-    , time                 >= 1.9.3    && < 1.13
+    , time                 >= 1.9.3    && < 1.15
     , turtle               >= 1.6.1    && < 1.7.0
     , vector               >= 0.11     && < 0.14
 
@@ -134,7 +134,7 @@ library
     , nonce                >= 1.0.7   && < 1.1
     , pqueue               >= 1.4.1.3 && < 1.6
     , safe-exceptions      >= 0.1.7   && < 0.2
-    , template-haskell     >= 2.16.0  && < 2.23
+    , template-haskell     >= 2.16.0  && < 2.24
     , unliftio             >= 0.2.15  && < 0.3
     , unliftio-core        >= 0.2.0   && < 0.3
     , unordered-containers >= 0.2.13  && < 0.3

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -133,7 +133,7 @@ library
     , data-default         >= 0.7     && < 0.9
     , network-conduit-tls  >= 1.3.2   && < 1.5
     , nonce                >= 1.0.7   && < 1.1
-    , pqueue               >= 1.4.1.3 && < 1.6
+    , pqueue               >= 1.4.1.3 && < 1.7
     , safe-exceptions      >= 0.1.7   && < 0.2
     , template-haskell     >= 2.16.0  && < 2.24
     , unliftio             >= 0.2.15  && < 0.3

--- a/grpc-mqtt.cabal
+++ b/grpc-mqtt.cabal
@@ -18,6 +18,7 @@ tested-with:
   GHC == 9.6.7
   GHC == 9.8.4
   GHC == 9.10.1
+  GHC == 9.12.2
 
 custom-setup
   setup-depends: base, Cabal, filepath

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -24,13 +24,9 @@ final: prev: {
 
             grpc-haskell = final.lib.pipe (hfinal.callPackage ../packages/grpc-haskell.nix { }) [
               final.haskell.lib.dontCheck
-              final.haskell.lib.doJailbreak
             ];
             grpc-haskell-core = final.lib.pipe (hfinal.callPackage ../packages/grpc-haskell-core.nix { gpr = final.grpc; }) [
               final.haskell.lib.dontCheck
-              final.haskell.lib.doJailbreak
-              (final.haskell.lib.compose.appendConfigureFlag "--ghc-option=-Wno-deriving-typeable")  # GHC 9.12
-              final.haskell.lib.dontHaddock  # TODO: the configure flags ^^ don't propagate to haddocks :(
             ];
           })
           (hfinal: _: {

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -8,13 +8,13 @@ final: prev: {
           (hfinal: hprev: {
             # Too tight bounds to support GHC 9.10
             # See: https://github.com/dustin/mqtt-hs/issues/52
-            net-mqtt = final.haskell.lib.doJailbreak hprev.net-mqtt;
+            net-mqtt = final.lib.pipe hprev.net-mqtt [
+              final.haskell.lib.unmarkBroken
+              final.haskell.lib.doJailbreak
+            ];
 
             # GHC 9.12 support
             pqueue = final.haskell.lib.doJailbreak hprev.pqueue;
-            optparse-generic = final.haskell.lib.doJailbreak hprev.optparse-generic;
-            insert-ordered-containers = final.haskell.lib.doJailbreak hprev.insert-ordered-containers;
-            swagger2 = final.haskell.lib.doJailbreak hprev.swagger2;
 
             proto3-wire = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-wire.nix  { });
             proto3-suite = final.lib.pipe (hfinal.callPackage ../packages/proto3-suite.nix { }) [

--- a/nix/overlays/haskell.nix
+++ b/nix/overlays/haskell.nix
@@ -10,15 +10,28 @@ final: prev: {
             # See: https://github.com/dustin/mqtt-hs/issues/52
             net-mqtt = final.haskell.lib.doJailbreak hprev.net-mqtt;
 
-            proto3-wire = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-wire.nix  { });
-            proto3-suite = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-suite.nix { });
+            # GHC 9.12 support
+            pqueue = final.haskell.lib.doJailbreak hprev.pqueue;
+            optparse-generic = final.haskell.lib.doJailbreak hprev.optparse-generic;
+            insert-ordered-containers = final.haskell.lib.doJailbreak hprev.insert-ordered-containers;
+            swagger2 = final.haskell.lib.doJailbreak hprev.swagger2;
 
-            grpc-haskell = final.haskell.lib.doJailbreak
-              (final.haskell.lib.dontCheck (hfinal.callPackage ../packages/grpc-haskell.nix { }));
-            grpc-haskell-core = final.haskell.lib.doJailbreak
-              (final.haskell.lib.dontCheck (hfinal.callPackage ../packages/grpc-haskell-core.nix {
-                 gpr = final.grpc;
-              }));
+            proto3-wire = final.haskell.lib.dontCheck (hfinal.callPackage ../packages/proto3-wire.nix  { });
+            proto3-suite = final.lib.pipe (hfinal.callPackage ../packages/proto3-suite.nix { }) [
+              final.haskell.lib.dontCheck
+              final.haskell.lib.doJailbreak
+            ];
+
+            grpc-haskell = final.lib.pipe (hfinal.callPackage ../packages/grpc-haskell.nix { }) [
+              final.haskell.lib.dontCheck
+              final.haskell.lib.doJailbreak
+            ];
+            grpc-haskell-core = final.lib.pipe (hfinal.callPackage ../packages/grpc-haskell-core.nix { gpr = final.grpc; }) [
+              final.haskell.lib.dontCheck
+              final.haskell.lib.doJailbreak
+              (final.haskell.lib.compose.appendConfigureFlag "--ghc-option=-Wno-deriving-typeable")  # GHC 9.12
+              final.haskell.lib.dontHaddock  # TODO: the configure flags ^^ don't propagate to haddocks :(
+            ];
           })
           (hfinal: _: {
             grpc-mqtt = (hfinal.callCabal2nix "grpc-mqtt" (gitignore.lib.gitignoreSource ../..) { }).overrideAttrs (old: {

--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.6.1";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "1j21cnhd1wbf0fn8vlrv7g6m10d1i7x31a9m1x4srwbqlc2ry51z";
-    rev = "ddf02163fa82f1f287351336fbe9e174b6e5b9db";
+    sha256 = "032157rn88plw7g0f901wh5i6w7hjhlcqfr30cvbcb6xz3wpv91p";
+    rev = "2f89b1ae6c27f521983248a95483123bedd89d05";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell-core.nix
+++ b/nix/packages/grpc-haskell-core.nix
@@ -8,8 +8,8 @@ mkDerivation {
   version = "0.6.1";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "032157rn88plw7g0f901wh5i6w7hjhlcqfr30cvbcb6xz3wpv91p";
-    rev = "2f89b1ae6c27f521983248a95483123bedd89d05";
+    sha256 = "1ix9lj4fj3qwq3yd91nlkbvkw26h4l32cmhh0887lkh76gv51akq";
+    rev = "e5d065bc2a2c14e2c48a9132ba1203b8ad3b073c";
     fetchSubmodules = true;
   };
   postUnpack = "sourceRoot+=/core; echo source root reset to $sourceRoot";

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "1j21cnhd1wbf0fn8vlrv7g6m10d1i7x31a9m1x4srwbqlc2ry51z";
-    rev = "ddf02163fa82f1f287351336fbe9e174b6e5b9db";
+    sha256 = "032157rn88plw7g0f901wh5i6w7hjhlcqfr30cvbcb6xz3wpv91p";
+    rev = "2f89b1ae6c27f521983248a95483123bedd89d05";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/packages/grpc-haskell.nix
+++ b/nix/packages/grpc-haskell.nix
@@ -9,8 +9,8 @@ mkDerivation {
   version = "0.4.0";
   src = fetchgit {
     url = "https://github.com/awakesecurity/gRPC-haskell.git";
-    sha256 = "032157rn88plw7g0f901wh5i6w7hjhlcqfr30cvbcb6xz3wpv91p";
-    rev = "2f89b1ae6c27f521983248a95483123bedd89d05";
+    sha256 = "1ix9lj4fj3qwq3yd91nlkbvkw26h4l32cmhh0887lkh76gv51akq";
+    rev = "e5d065bc2a2c14e2c48a9132ba1203b8ad3b073c";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/packages/proto3-suite.nix
+++ b/nix/packages/proto3-suite.nix
@@ -11,11 +11,11 @@
 }:
 mkDerivation {
   pname = "proto3-suite";
-  version = "0.9.2";
+  version = "0.9.4";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-suite.git";
-    sha256 = "1nw7r4l1148v961bdxswb93ziqdg07lf6yfv555xr5vsx7fa8i92";
-    rev = "dac138b2d1d179ba79824aad8acd126ad61ae935";
+    sha256 = "1sr87ccn92h7vrc8gwk9lv19is3z30ny0k976s5azhbv5sl6r66h";
+    rev = "be604b64258061292e264c1ce3d87432530d18b3";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/packages/proto3-suite.nix
+++ b/nix/packages/proto3-suite.nix
@@ -15,7 +15,7 @@ mkDerivation {
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-suite.git";
     sha256 = "1sr87ccn92h7vrc8gwk9lv19is3z30ny0k976s5azhbv5sl6r66h";
-    rev = "be604b64258061292e264c1ce3d87432530d18b3";
+    rev = "16358c5cca541d85441de1b830bc951d42048593";
     fetchSubmodules = true;
   };
   isLibrary = true;

--- a/nix/packages/proto3-wire.nix
+++ b/nix/packages/proto3-wire.nix
@@ -6,11 +6,11 @@
 }:
 mkDerivation {
   pname = "proto3-wire";
-  version = "1.4.5";
+  version = "1.4.6";
   src = fetchgit {
     url = "https://github.com/awakesecurity/proto3-wire.git";
-    sha256 = "0nb8xy723jhybrfsyfcgpczgbv80hcndprc45h3zq9hliam07qqv";
-    rev = "d4376fb6f1c1ac03ee8ec5c5793700ca6508ea70";
+    sha256 = "1nidk369y7gwjbcg4c1wg4q7kjbskyfj2xxbhs0qk16c7nvmay7n";
+    rev = "fcc53d9935b64b6d8aaf65c8cef17f4bbed56867";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -421,7 +422,10 @@ data ClientTopicError
   | -- | Exception that is raised when preparing a request for RPC method with a
     -- name that does not form a valid MQTT topic.
     BadRPCMethodTopicError Text
-  deriving stock (Eq, Ord, Typeable)
+  deriving stock (Eq, Ord)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- | @since 1.0.0
 instance Exception ClientTopicError

--- a/src/Network/GRPC/MQTT/Client.hs
+++ b/src/Network/GRPC/MQTT/Client.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE BlockArguments #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
@@ -423,9 +422,6 @@ data ClientTopicError
     -- name that does not form a valid MQTT topic.
     BadRPCMethodTopicError Text
   deriving stock (Eq, Ord)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- | @since 1.0.0
 instance Exception ClientTopicError

--- a/src/Network/GRPC/MQTT/Compress.hs
+++ b/src/Network/GRPC/MQTT/Compress.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Module      :  Network.GRPC.MQTT.Compress
 -- Copyright   :  (c) Arista Networks, 2022-2023
@@ -65,7 +67,10 @@ compress level bytes
 --
 -- @since 1.0.0
 newtype ZstdError = ZstdError {getZstdError :: String}
-  deriving stock (Data, Eq, Ord, Show, Typeable)
+  deriving stock (Data, Eq, Ord, Show)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- | @since 1.0.0
 instance Exception ZstdError where

--- a/src/Network/GRPC/MQTT/Compress.hs
+++ b/src/Network/GRPC/MQTT/Compress.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- |
 -- Module      :  Network.GRPC.MQTT.Compress
 -- Copyright   :  (c) Arista Networks, 2022-2023
@@ -68,9 +66,6 @@ compress level bytes
 -- @since 1.0.0
 newtype ZstdError = ZstdError {getZstdError :: String}
   deriving stock (Data, Eq, Ord, Show)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- | @since 1.0.0
 instance Exception ZstdError where

--- a/src/Network/GRPC/MQTT/Message.hs
+++ b/src/Network/GRPC/MQTT/Message.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 -- |
 -- Module      :  Network.GRPC.MQTT.Message
@@ -130,7 +131,10 @@ data WireDecodeError
   | -- | 'DecodeZstdError' is emitted when a zstandard error is thrown while
     -- decompressing the 'ByteString'.
     DecodeZstdError ZstdError
-  deriving stock (Eq, Ord, Show, Typeable)
+  deriving stock (Eq, Ord, Show)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 throwWireError :: MonadError WireDecodeError m => ParseError -> m a
 throwWireError err = throwError (DecodeWireError err)

--- a/src/Network/GRPC/MQTT/Message.hs
+++ b/src/Network/GRPC/MQTT/Message.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 -- |
 -- Module      :  Network.GRPC.MQTT.Message
@@ -132,9 +131,6 @@ data WireDecodeError
     -- decompressing the 'ByteString'.
     DecodeZstdError ZstdError
   deriving stock (Eq, Ord, Show)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 throwWireError :: MonadError WireDecodeError m => ParseError -> m a
 throwWireError err = throwError (DecodeWireError err)

--- a/src/Network/GRPC/MQTT/Message/Request/Core.hs
+++ b/src/Network/GRPC/MQTT/Message/Request/Core.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Request.Core
@@ -61,9 +60,6 @@ data Request msg = Request
   }
   deriving stock (Eq, Ord, Show)
   deriving stock (Data, Generic)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- | @since 1.0.0
 instance Functor Request where

--- a/src/Network/GRPC/MQTT/Message/Request/Core.hs
+++ b/src/Network/GRPC/MQTT/Message/Request/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 
 -- |
 -- Module      :  Network.GRPC.MQTT.Message.Request.Core
@@ -59,7 +60,10 @@ data Request msg = Request
     metadata :: MetadataMap
   }
   deriving stock (Eq, Ord, Show)
-  deriving stock (Data, Generic, Typeable)
+  deriving stock (Data, Generic)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- | @since 1.0.0
 instance Functor Request where

--- a/src/Network/GRPC/MQTT/Option/Batched.hs
+++ b/src/Network/GRPC/MQTT/Option/Batched.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -102,8 +103,11 @@ import Network.GRPC.MQTT.Proto (ProtoDatum)
 -- @since 1.0.0
 newtype Batched = Batch {getBatched :: Bool}
   deriving newtype (Primitive, ProtoDatum)
-  deriving stock (Data, Eq, Ord, Generic, Lift, Typeable)
+  deriving stock (Data, Eq, Ord, Generic, Lift)
   deriving anyclass (Message, ProtoEnum)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- | Pattern synonym for enabled batching.
 --

--- a/src/Network/GRPC/MQTT/Option/Batched.hs
+++ b/src/Network/GRPC/MQTT/Option/Batched.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
@@ -105,9 +104,6 @@ newtype Batched = Batch {getBatched :: Bool}
   deriving newtype (Primitive, ProtoDatum)
   deriving stock (Data, Eq, Ord, Generic, Lift)
   deriving anyclass (Message, ProtoEnum)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- | Pattern synonym for enabled batching.
 --

--- a/src/Network/GRPC/MQTT/Proto.hs
+++ b/src/Network/GRPC/MQTT/Proto.hs
@@ -489,9 +489,6 @@ data ProtoOptionError
     -- @
     OptionValueTypeMismatch DatumRep DotProtoOption
   deriving stock (Data, Eq, Generic, Ord, Show)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- | @since 1.0.0
 instance Exception ProtoOptionError where

--- a/src/Network/GRPC/MQTT/Proto.hs
+++ b/src/Network/GRPC/MQTT/Proto.hs
@@ -91,7 +91,12 @@ where
 
 --------------------------------------------------------------------------------
 
-import Control.Exception (ErrorCall (ErrorCallWithLocation), throwIO)
+import Control.Exception (throwIO)
+#if MIN_VERSION_base(4,21,0)
+import Control.Exception (ErrorCall (ErrorCall))
+#else
+import Control.Exception (ErrorCall (ErrorCallWithLocation))
+#endif
 
 import Control.Monad.Except (MonadError, throwError)
 
@@ -212,10 +217,12 @@ throwProtoPathIsDirectoryIO = throwProtoIO ProtoPathIsDirectory
 --
 -- @since 1.0.0
 throwCompileErrorIO :: Turtle.FilePath -> CompileError -> IO a
-throwCompileErrorIO filepath err =
-  let issue :: ErrorCall
-      issue = ErrorCallWithLocation filepath (showCompileError err)
-   in throwIO issue
+#if MIN_VERSION_base(4,21,0)
+throwCompileErrorIO _filepath err = throwIO $ ErrorCall $ showCompileError err
+#else
+throwCompileErrorIO filepath err = throwIO $ ErrorCallWithLocation filepath $ showCompileError err
+#endif
+
 
 throwProtoIO :: ProtoIOErrorTag -> Turtle.FilePath -> IO a
 throwProtoIO tag filepath = throwIO (ProtoIOError filepath tag)
@@ -481,7 +488,10 @@ data ProtoOptionError
     -- }
     -- @
     OptionValueTypeMismatch DatumRep DotProtoOption
-  deriving stock (Data, Eq, Generic, Ord, Show, Typeable)
+  deriving stock (Data, Eq, Generic, Ord, Show)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- | @since 1.0.0
 instance Exception ProtoOptionError where

--- a/src/Network/GRPC/MQTT/Serial.hs
+++ b/src/Network/GRPC/MQTT/Serial.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 -- |
 -- Module      :  Network.GRPC.MQTT.Serial
 -- Copyright   :  (c) Arista Networks, 2022-2023
@@ -64,7 +66,10 @@ data WireEncodeOptions = WireEncodeOptions
     -- are published by a streaming RPC method type.
     encodeBatched :: Batched
   }
-  deriving stock (Data, Eq, Ord, Lift, Show, Typeable)
+  deriving stock (Data, Eq, Ord, Lift, Show)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- Wire Encoding Options - Construction ----------------------------------------
 
@@ -119,7 +124,10 @@ newtype WireDecodeOptions = WireDecodeOptions
     -- applied to a 'ByteString' before it is parsed during deserialization.
     decodeDecompress :: Bool
   }
-  deriving stock (Data, Eq, Ord, Lift, Show, Typeable)
+  deriving stock (Data, Eq, Ord, Lift, Show)
+#if !MIN_VERSION_base(4,21,0)
+  deriving stock (Typeable)
+#endif
 
 -- Wire Decoding Options - Construction ----------------------------------------
 

--- a/src/Network/GRPC/MQTT/Serial.hs
+++ b/src/Network/GRPC/MQTT/Serial.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- |
 -- Module      :  Network.GRPC.MQTT.Serial
 -- Copyright   :  (c) Arista Networks, 2022-2023
@@ -67,9 +65,6 @@ data WireEncodeOptions = WireEncodeOptions
     encodeBatched :: Batched
   }
   deriving stock (Data, Eq, Ord, Lift, Show)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- Wire Encoding Options - Construction ----------------------------------------
 
@@ -125,9 +120,6 @@ newtype WireDecodeOptions = WireDecodeOptions
     decodeDecompress :: Bool
   }
   deriving stock (Data, Eq, Ord, Lift, Show)
-#if !MIN_VERSION_base(4,21,0)
-  deriving stock (Typeable)
-#endif
 
 -- Wire Decoding Options - Construction ----------------------------------------
 

--- a/test/Test/Suite/Config.hs
+++ b/test/Test/Suite/Config.hs
@@ -210,7 +210,7 @@ askRemoteConfigMQTT = do
 
 data TestOption (opt :: Symbol) (a :: Type) :: Type where
   TestOption :: forall opt a. {getTestOption :: a} -> TestOption opt a
-  deriving (Typeable, Show)
+  deriving (Show)
 
 -- | Identitical to 'Tasty.askOption' except for handling the unwrapping of
 -- 'TestOption', intended to be used via type application:


### PR DESCRIPTION
Makes Typeable derive conditional as it is autoderived in 9.12.

ErrorCallWithLocation is now deprecated
> Deprecated: ErrorCallWithLocation has been deprecated in favour of ErrorCall (which does not have a location). Backtraces are now handled by the backtrace exception mechanisms exclusively.